### PR TITLE
Listing and changing of mode settings

### DIFF
--- a/docs/source/apps/contrib/admin.rst
+++ b/docs/source/apps/contrib/admin.rst
@@ -28,7 +28,7 @@ Maps
 Skip map
 ~~~~~~~~
 Command:
-  ``//next``
+  ``//next`` / ``//skip``
 Parameters:
   None.
 Functionality:
@@ -183,6 +183,19 @@ Parameters:
   * Game mode 'ta', 'laps', 'rounds', 'cup' or any script name (e.g. 'Rounds.Script.txt')
 Functionality:
   Changes the server game mode script.
+Required permission:
+  ``admin:mode``, requires admin level 2.
+
+Get/set game mode settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Command:
+  ``//modesettings``
+Parameters:
+  None, or:
+  * Setting name
+  * New setting value
+Functionality:
+  Displays a list of current mode settings (no parameters) or changes a setting according with the given parameters.
 Required permission:
   ``admin:mode``, requires admin level 2.
 

--- a/pyplanet/apps/contrib/admin/server.py
+++ b/pyplanet/apps/contrib/admin/server.py
@@ -3,6 +3,8 @@ Server Admin methods and functions.
 """
 from pyplanet.contrib.command import Command
 
+from pyplanet.apps.contrib.admin.views import ModeSettingsListView
+
 
 class ServerAdmin:
 	def __init__(self, app):
@@ -22,7 +24,8 @@ class ServerAdmin:
 			Command(command='setpassword', aliases=['srvpass'], target=self.set_password, perms='admin:password', admin=True).add_param(name='password', required=False),
 			Command(command='setspecpassword', aliases=['spectpass'], target=self.set_spec_password, perms='admin:password', admin=True).add_param(name='password', required=False),
 			Command(command='servername', target=self.set_servername, perms='admin:servername', admin=True).add_param(name='server_name', required=True, nargs='*'),
-			Command(command='mode', target=self.set_mode, perms='admin:mode', admin=True).add_param(name='mode', required=True, nargs='*')
+			Command(command='mode', target=self.set_mode, perms='admin:mode', admin=True).add_param(name='mode', required=True, nargs='*'),
+			Command(command='modesettings', target=self.get_mode_settings, perms='admin:mode', admin=True)#.add_param(name='mode', required=True, nargs='*')
 		)
 
 	async def set_mode(self, player, data, **kwargs):
@@ -49,6 +52,10 @@ class ServerAdmin:
 			player.nickname, mode
 		)
 		await self.instance.gbx.execute('ChatSendServerMessage', message)
+
+	async def get_mode_settings(self, player, data, **kwargs):
+		view = ModeSettingsListView(self.app)
+		await view.display(player=player.login)
 
 	async def set_servername(self, player, data, **kwargs):
 		name = ' '.join(data.server_name)

--- a/pyplanet/apps/contrib/admin/server.py
+++ b/pyplanet/apps/contrib/admin/server.py
@@ -26,7 +26,9 @@ class ServerAdmin:
 			Command(command='setspecpassword', aliases=['spectpass'], target=self.set_spec_password, perms='admin:password', admin=True).add_param(name='password', required=False),
 			Command(command='servername', target=self.set_servername, perms='admin:servername', admin=True).add_param(name='server_name', required=True, nargs='*'),
 			Command(command='mode', target=self.set_mode, perms='admin:mode', admin=True).add_param(name='mode', required=True, nargs='*'),
-			Command(command='modesettings', target=self.mode_settings, perms='admin:mode', admin=True).add_param(name='content', required=False, nargs='*')
+			Command(command='modesettings', target=self.mode_settings, perms='admin:mode', admin=True)
+				.add_param(name='setting', required=False)
+				.add_param(name='content', required=False)
 		)
 
 	async def set_mode(self, player, data, **kwargs):
@@ -55,29 +57,29 @@ class ServerAdmin:
 		await self.instance.gbx.execute('ChatSendServerMessage', message)
 
 	async def mode_settings(self, player, data, **kwargs):
-		setting_name = None
-		if data.content is not None:
-			setting_name = data.content[0]
-
+		setting_name = data.setting
 		if setting_name is None:
 			view = ModeSettingsListView(self.app)
 			await view.display(player=player.login)
 		else:
-			if len(data.content) != 2:
+			if not data.content:
 				message = '$z$s$fff» $i$f00Setting a mode setting requires $fff2$f00 parameters.'
 				await self.instance.gbx.execute('ChatSendServerMessageToLogin', message, player.login)
+				return
 
 			current_settings = await self.instance.mode_manager.get_settings()
-			setting_value = data.content[1]
+			setting_value = data.content
 			if setting_name not in current_settings:
 				message = '$z$s$fff» $i$f00Unknown mode setting "$fff{}$f00".'.format(setting_name)
 				await self.instance.gbx.execute('ChatSendServerMessageToLogin', message, player.login)
+				return
 
 			current_value = current_settings[setting_name]
 			current_type = type(current_value)
+
+			type_setting = None
 			try:
-				type_setting = None
-				if type(current_value) is bool:
+				if isinstance(current_value. bool):
 					lower_setting_value = setting_value.lower()
 					if lower_setting_value == 'true' or setting_value == '1':
 						type_setting = True

--- a/pyplanet/apps/contrib/admin/views.py
+++ b/pyplanet/apps/contrib/admin/views.py
@@ -1,0 +1,36 @@
+from pyplanet.views.generics.list import ManualListView
+
+
+class ModeSettingsListView(ManualListView):
+	title = 'Current mode settings'
+	icon_style = 'Icons128x128_1'
+	icon_substyle = 'Browse'
+
+	def __init__(self, app):
+		super().__init__(self)
+		self.app = app
+		self.manager = app.context.ui
+
+	async def get_data(self):
+		settings = []
+		current_settings = await self.app.instance.mode_manager.get_settings()
+		for setting in current_settings:
+			settings.append(dict(name=setting,value=current_settings[setting]))
+		return settings
+
+	async def get_fields(self):
+		return [
+			{
+				'name': 'Name',
+				'index': 'name',
+				'sorting': True,
+				'searching': True,
+				'width': 60,
+				'type': 'label'
+			},
+			{
+				'name': 'Current Value',
+				'index': 'value',
+				'width': 140
+			},
+		]


### PR DESCRIPTION
Adding the //modesettings command:
- with no parameters it displays a list of current mode settings
- to set a setting, use the setting name as 1st parameter and new value as 2nd (f.e. //modesettings S_TimeLimit 360)

Changing a setting will cast variable to proper type (and post chat error on exception).

Closes #156.