### PR TITLE
Added setting to restrict karma voting until after finishing the map

### DIFF
--- a/pyplanet/apps/contrib/karma/app.py
+++ b/pyplanet/apps/contrib/karma/app.py
@@ -77,7 +77,7 @@ class Karma(AppConfig):
 		if not cmd:
 			if self.instance.game.game == 'tm':
 				finishes_required = await self.setting_finishes_before_voting.get_value()
-				player_finishes = len(await Score.objects.execute(Score.select().where(Score.map_id == self.instance.map_manager.current_map.get_id()).where(Score.player_id == player.get_id())))
+				player_finishes = await Score.objects.execute(Score.select().where(Score.map_id == self.instance.map_manager.current_map.get_id()).where(Score.player_id == player.get_id()).count())
 				if player_finishes < finishes_required:
 					message = '$z$s$fff» $i$f00You have to finish this map at least $fff{}$f00 times before voting!'.format(finishes_required)
 					await self.instance.gbx.execute('ChatSendServerMessageToLogin', message, player.login)

--- a/pyplanet/apps/contrib/karma/app.py
+++ b/pyplanet/apps/contrib/karma/app.py
@@ -77,7 +77,7 @@ class Karma(AppConfig):
 		if not cmd:
 			if self.instance.game.game == 'tm':
 				finishes_required = await self.setting_finishes_before_voting.get_value()
-				player_finishes = await Score.objects.execute(Score.select().where(Score.map_id == self.instance.map_manager.current_map.get_id()).where(Score.player_id == player.get_id()).count())
+				player_finishes = await Score.objects.count(Score.select().where(Score.map_id == self.instance.map_manager.current_map.get_id()).where(Score.player_id == player.get_id()))
 				if player_finishes < finishes_required:
 					message = '$z$s$fff» $i$f00You have to finish this map at least $fff{}$f00 times before voting!'.format(finishes_required)
 					await self.instance.gbx.execute('ChatSendServerMessageToLogin', message, player.login)

--- a/pyplanet/contrib/setting/setting.py
+++ b/pyplanet/contrib/setting/setting.py
@@ -126,7 +126,7 @@ class Setting:
 
 		if self.type == list or self.type == set or self.type == dict:
 			return json.dumps(value)
-		return value
+		return str(value)
 
 	@property
 	def type_name(self):


### PR DESCRIPTION
Added setting to determine how many times a player must finish the map before being allowed to vote. Only enabled in TrackMania. Closes #99.