### PR TITLE
Added performance mode + implementations in records widgets

### DIFF
--- a/pyplanet/apps/contrib/dedimania/views.py
+++ b/pyplanet/apps/contrib/dedimania/views.py
@@ -22,11 +22,12 @@ class DedimaniaRecordsWidget(TimesWidgetView):
 		self.id = 'pyplanet__widgets_dedimaniarecords'
 
 		self.action = self.action_recordlist
+		self.record_amount = math.floor((self.size_y - 5.5) / 3.3)
 
 	async def get_player_data(self):
 		data = await super().get_player_data()
-
-		record_amount = math.floor((self.size_y - 5.5) / 3.3)
+		if self.app.instance.performance_mode:
+			return data
 
 		widget_times = dict()
 
@@ -42,7 +43,7 @@ class DedimaniaRecordsWidget(TimesWidgetView):
 			custom_start_index = None
 			if player_index > len(self.app.current_records):
 				# No personal record, get the last records
-				records_start = (len(self.app.current_records) - record_amount + self.top_entries)
+				records_start = (len(self.app.current_records) - self.record_amount + self.top_entries)
 				# If start of current slice is in the top entries, add more records below
 				if records_start < self.top_entries:
 					records_start = (self.top_entries)
@@ -52,12 +53,12 @@ class DedimaniaRecordsWidget(TimesWidgetView):
 			else:
 				if player_index <= self.top_entries:
 					# Player record is in top X, get following records (top entries + 1 onwards)
-					records += self.app.current_records[(self.top_entries + 1):(record_amount + 1)]
+					records += self.app.current_records[(self.top_entries + 1):(self.record_amount + 1)]
 					custom_start_index = (self.top_entries + 1)
 				else:
 					# Player record is not in top X, get records around player record
 					# Same amount above the record as below, except when not possible (favors above)
-					records_to_fill = (record_amount - self.top_entries)
+					records_to_fill = (self.record_amount - self.top_entries)
 					start_point = ((player_index - math.ceil((records_to_fill - 1) / 2)) - 1)
 					end_point = ((player_index + math.floor((records_to_fill - 1) / 2)) - 1)
 
@@ -106,6 +107,27 @@ class DedimaniaRecordsWidget(TimesWidgetView):
 		context.update({
 			'top_entries': self.top_entries
 		})
+
+		if self.app.instance.performance_mode:
+			list_records = list()
+			records = list(self.app.current_records[:self.record_amount])
+
+			index = 1
+			for record in records:
+				record_player = await record.get_related('player')
+				list_record = dict()
+				list_record['index'] = index
+				list_record['color'] = '$fff'
+				if index <= self.top_entries:
+					list_record['color'] = '$ff0'
+				list_record['nickname'] = record_player.nickname
+				list_record['score'] = times.format_time(int(record.score))
+				index += 1
+				list_records.append(list_record)
+
+			context.update({
+				'times': list_records
+			})
 
 		return context
 

--- a/pyplanet/apps/contrib/local_records/app.py
+++ b/pyplanet/apps/contrib/local_records/app.py
@@ -41,8 +41,6 @@ class LocalRecords(AppConfig):
 		self.widget = LocalRecordsWidget(self)
 		await self.widget.display()
 
-		await self.instance.setting_manager.get_setting()
-
 	async def refresh_locals(self):
 		record_list = await LocalRecord.objects.execute(
 			LocalRecord.select().where(

--- a/pyplanet/apps/contrib/local_records/app.py
+++ b/pyplanet/apps/contrib/local_records/app.py
@@ -41,6 +41,8 @@ class LocalRecords(AppConfig):
 		self.widget = LocalRecordsWidget(self)
 		await self.widget.display()
 
+		await self.instance.setting_manager.get_setting()
+
 	async def refresh_locals(self):
 		record_list = await LocalRecord.objects.execute(
 			LocalRecord.select().where(

--- a/pyplanet/apps/core/pyplanet/app.py
+++ b/pyplanet/apps/core/pyplanet/app.py
@@ -18,22 +18,12 @@ class PyPlanetConfig(AppConfig):
 		# Initiate logo view.
 		self.logo = LogoView(manager=self.context.ui)
 
-		# Performance mode setting
-		self.setting_performance_mode = Setting(
-			'performance_mode', 'Performance mode playercount', Setting.CAT_BEHAVIOUR, type=int,
-			description='Above this amount of players the performance mode will be enabled.',
-			default=30
-		)
-
 	async def on_init(self):
 		# Call components.
 		await self.setting.on_init()
 		await self.dev.on_init()
 
 	async def on_start(self):
-		# Register performance mode setting
-		await self.context.setting.register(self.setting_performance_mode)
-
 		# Call components.
 		await self.setting.on_start()
 		await self.dev.on_start()

--- a/pyplanet/apps/core/pyplanet/app.py
+++ b/pyplanet/apps/core/pyplanet/app.py
@@ -2,6 +2,7 @@ from pyplanet.apps.config import AppConfig
 from pyplanet.apps.core.pyplanet.dev import DevComponent
 from pyplanet.apps.core.pyplanet.setting import SettingComponent
 from pyplanet.apps.core.pyplanet.views.logo import LogoView
+from pyplanet.contrib.setting import Setting
 
 
 class PyPlanetConfig(AppConfig):
@@ -17,6 +18,13 @@ class PyPlanetConfig(AppConfig):
 		# Initiate logo view.
 		self.logo = LogoView(manager=self.context.ui)
 
+		# Performance mode setting
+		self.setting_performance_mode = Setting(
+			'performance_mode', 'Performance mode playercount', Setting.CAT_BEHAVIOUR, type=int,
+			description='Above this amount of players the performance mode will be enabled.',
+			default=30
+		)
+
 	async def on_init(self):
 		# Call components.
 		await self.setting.on_init()
@@ -24,7 +32,7 @@ class PyPlanetConfig(AppConfig):
 
 	async def on_start(self):
 		# Register performance mode setting
-		await self.context.setting.register(self.instance.performance_mode)
+		await self.context.setting.register(self.setting_performance_mode)
 
 		# Call components.
 		await self.setting.on_start()

--- a/pyplanet/apps/core/pyplanet/app.py
+++ b/pyplanet/apps/core/pyplanet/app.py
@@ -2,6 +2,7 @@ from pyplanet.apps.config import AppConfig
 from pyplanet.apps.core.pyplanet.dev import DevComponent
 from pyplanet.apps.core.pyplanet.setting import SettingComponent
 from pyplanet.apps.core.pyplanet.views.logo import LogoView
+from pyplanet.contrib.setting import Setting
 
 
 class PyPlanetConfig(AppConfig):
@@ -17,12 +18,22 @@ class PyPlanetConfig(AppConfig):
 		# Initiate logo view.
 		self.logo = LogoView(manager=self.context.ui)
 
+		# Performance mode setting
+		self.setting_performance_mode = Setting(
+			'performance_mode', 'Performance mode playercount', Setting.CAT_BEHAVIOUR, type=int,
+			description='Above this amount of players the performance mode will be enabled.',
+			default=30
+		)
+
 	async def on_init(self):
 		# Call components.
 		await self.setting.on_init()
 		await self.dev.on_init()
 
 	async def on_start(self):
+		# Register performance mode setting
+		await self.context.setting.register(self.setting_performance_mode)
+
 		# Call components.
 		await self.setting.on_start()
 		await self.dev.on_start()

--- a/pyplanet/apps/core/pyplanet/app.py
+++ b/pyplanet/apps/core/pyplanet/app.py
@@ -2,7 +2,6 @@ from pyplanet.apps.config import AppConfig
 from pyplanet.apps.core.pyplanet.dev import DevComponent
 from pyplanet.apps.core.pyplanet.setting import SettingComponent
 from pyplanet.apps.core.pyplanet.views.logo import LogoView
-from pyplanet.contrib.setting import Setting
 
 
 class PyPlanetConfig(AppConfig):
@@ -18,13 +17,6 @@ class PyPlanetConfig(AppConfig):
 		# Initiate logo view.
 		self.logo = LogoView(manager=self.context.ui)
 
-		# Performance mode setting
-		self.setting_performance_mode = Setting(
-			'performance_mode', 'Performance mode playercount', Setting.CAT_BEHAVIOUR, type=int,
-			description='Above this amount of players the performance mode will be enabled.',
-			default=30
-		)
-
 	async def on_init(self):
 		# Call components.
 		await self.setting.on_init()
@@ -32,7 +24,7 @@ class PyPlanetConfig(AppConfig):
 
 	async def on_start(self):
 		# Register performance mode setting
-		await self.context.setting.register(self.setting_performance_mode)
+		await self.context.setting.register(self.instance.performance_mode)
 
 		# Call components.
 		await self.setting.on_start()

--- a/pyplanet/apps/core/pyplanet/views/setting.py
+++ b/pyplanet/apps/core/pyplanet/views/setting.py
@@ -46,9 +46,7 @@ class SettingMenuView(ManualListView):
 			return
 
 		# Getting the setting itself.
-		setting = await self.app.instance.setting_manager\
-			.get_app_manager(row['app_label'])\
-			.get_setting(row['key'], prefetch_values=True)
+		setting = await self.app.instance.setting_manager.get_setting(row['app_label'], row['key'], prefetch_values=True)
 
 		# Show edit view.
 		self.child = SettingEditView(self, self.player, setting)

--- a/pyplanet/contrib/setting/core_settings.py
+++ b/pyplanet/contrib/setting/core_settings.py
@@ -1,0 +1,8 @@
+from pyplanet.contrib.setting import Setting
+
+# Performance mode setting
+performance_mode = Setting(
+	'performance_mode', 'Performance mode playercount', Setting.CAT_BEHAVIOUR, type=int,
+	description='Above this amount of players the performance mode will be enabled.',
+	default=30
+)

--- a/pyplanet/contrib/setting/manager.py
+++ b/pyplanet/contrib/setting/manager.py
@@ -30,28 +30,6 @@ class _BaseSettingManager:
 		# Register the setting.
 		self._settings.extend(settings)
 
-	async def get_setting(self, key, prefetch_values=True):
-		"""
-		Get setting by key and optionally fetch the value if not yet fetched.
-
-		:param key: Key string
-		:param prefetch_values: Prefetch the values if not yet fetched?
-		:return: Setting instance.
-		:raise: SettingException
-		"""
-		setting = None
-		for s in self._settings:
-			if s.key == key:
-				setting = s
-				break
-
-		if not setting:
-			raise SettingException('Setting with key not found')
-
-		if prefetch_values and setting._value[0] is False:
-			await setting.get_value()
-		return setting
-
 
 class GlobalSettingManager(_BaseSettingManager, CoreContrib):
 	"""
@@ -104,6 +82,18 @@ class GlobalSettingManager(_BaseSettingManager, CoreContrib):
 		for app, manager in self.app_managers.items():
 			for setting in manager._settings:
 				yield setting
+
+	async def get_setting(self, app_label, key, prefetch_values=True):
+		"""
+		Get setting by key and optionally fetch the value if not yet fetched.
+
+		:param app_label: Namespace (mostly app label).
+		:param key: Key string
+		:param prefetch_values: Prefetch the values if not yet fetched?
+		:return: Setting instance.
+		:raise: SettingException
+		"""
+		return await self.get_app_manager(app_label).get_setting(key, prefetch_values)
 
 	async def get_apps(self, prefetch_values=True):
 		"""
@@ -223,6 +213,28 @@ class AppSettingManager(_BaseSettingManager):
 
 		# Register the setting.
 		self._settings.extend(settings)
+
+	async def get_setting(self, key, prefetch_values=True):
+		"""
+		Get setting by key and optionally fetch the value if not yet fetched.
+
+		:param key: Key string
+		:param prefetch_values: Prefetch the values if not yet fetched?
+		:return: Setting instance.
+		:raise: SettingException
+		"""
+		setting = None
+		for s in self._settings:
+			if s.key == key:
+				setting = s
+				break
+
+		if not setting:
+			raise SettingException('Setting with key not found')
+
+		if prefetch_values and setting._value[0] is False:
+			await setting.get_value()
+		return setting
 
 	def get_categories(self):
 		"""

--- a/pyplanet/contrib/setting/manager.py
+++ b/pyplanet/contrib/setting/manager.py
@@ -2,6 +2,7 @@ import asyncio
 
 from pyplanet.apps import AppConfig
 from pyplanet.contrib import CoreContrib
+from pyplanet.contrib.setting.core_settings import performance_mode
 from pyplanet.contrib.setting.exceptions import SettingException
 
 
@@ -46,6 +47,10 @@ class GlobalSettingManager(_BaseSettingManager, CoreContrib):
 	def __init__(self, instance):
 		super().__init__(instance)
 		self.app_managers = dict()
+
+	async def on_start(self):
+		# Register core global settings.
+		await self.register(performance_mode)
 
 	def create_app_manager(self, app_config):
 		"""
@@ -93,6 +98,19 @@ class GlobalSettingManager(_BaseSettingManager, CoreContrib):
 		:return: Setting instance.
 		:raise: SettingException
 		"""
+		if app_label is None:
+			setting = None
+			for s in self._settings:
+				if s.key == key:
+					setting = s
+					break
+
+			if not setting:
+				raise SettingException('Setting with key not found')
+
+			if prefetch_values and setting._value[0] is False:
+				await setting.get_value()
+			return setting
 		return await self.get_app_manager(app_label).get_setting(key, prefetch_values)
 
 	async def get_apps(self, prefetch_values=True):

--- a/pyplanet/core/instance.py
+++ b/pyplanet/core/instance.py
@@ -102,6 +102,15 @@ class Instance:
 			logger.exception(e)
 			raise
 
+	@property
+	def performance_mode(self):
+		"""
+		Gives back a boolean, True if we are in performance mode.
+		
+		:return: Performance mode boolean.
+		"""
+		return self.player_manager.performance_mode
+
 	async def __fire_signal(self, signal):  # pragma: no cover
 		"""
 		Fire signal with given name to all listeners.
@@ -131,11 +140,11 @@ class Instance:
 		await self.__fire_signal(signals.pyplanet_start_db_after)
 
 		# Start the core contribs.
+		await self.setting_manager.on_start()
 		await self.map_manager.on_start()
 		await self.player_manager.on_start()
 		await self.permission_manager.on_start()
 		await self.command_manager.on_start()
-		await self.setting_manager.on_start()
 		await self.mode_manager.on_start()
 
 		# Start the apps, call the on_ready, resulting in apps user logic to be started.

--- a/pyplanet/core/instance.py
+++ b/pyplanet/core/instance.py
@@ -19,7 +19,7 @@ from pyplanet.contrib.map import MapManager
 from pyplanet.contrib.player import PlayerManager
 from pyplanet.contrib.command import CommandManager
 from pyplanet.contrib.permission import PermissionManager
-from pyplanet.contrib.setting import GlobalSettingManager, Setting
+from pyplanet.contrib.setting import GlobalSettingManager
 from pyplanet.contrib.mode import ModeManager
 
 logger = logging.getLogger(__name__)
@@ -73,13 +73,6 @@ class Instance:
 		self.command_manager =		CommandManager(self)
 		self.setting_manager =		GlobalSettingManager(self)
 		self.mode_manager =			ModeManager(self)
-
-		# Build in settings.
-		self.performance_mode = Setting(
-			'performance_mode', 'Performance mode playercount', Setting.CAT_BEHAVIOUR, type=int,
-			description='Above this amount of players the performance mode will be enabled.',
-			default=30
-		)
 
 		# Populate apps.
 		self.apps.populate(settings.MANDATORY_APPS, in_order=True)

--- a/pyplanet/core/instance.py
+++ b/pyplanet/core/instance.py
@@ -19,7 +19,7 @@ from pyplanet.contrib.map import MapManager
 from pyplanet.contrib.player import PlayerManager
 from pyplanet.contrib.command import CommandManager
 from pyplanet.contrib.permission import PermissionManager
-from pyplanet.contrib.setting import GlobalSettingManager
+from pyplanet.contrib.setting import GlobalSettingManager, Setting
 from pyplanet.contrib.mode import ModeManager
 
 logger = logging.getLogger(__name__)
@@ -73,6 +73,13 @@ class Instance:
 		self.command_manager =		CommandManager(self)
 		self.setting_manager =		GlobalSettingManager(self)
 		self.mode_manager =			ModeManager(self)
+
+		# Build in settings.
+		self.performance_mode = Setting(
+			'performance_mode', 'Performance mode playercount', Setting.CAT_BEHAVIOUR, type=int,
+			description='Above this amount of players the performance mode will be enabled.',
+			default=30
+		)
 
 		# Populate apps.
 		self.apps.populate(settings.MANDATORY_APPS, in_order=True)

--- a/pyplanet/core/signals.py
+++ b/pyplanet/core/signals.py
@@ -16,7 +16,11 @@ pyplanet_start_db_after		= _Signal(code='start_db_after', namespace='pyplanet')
 pyplanet_start_apps_before	= _Signal(code='start_apps_before', namespace='pyplanet')
 pyplanet_start_apps_after	= _Signal(code='start_apps_after', namespace='pyplanet')
 
+pyplanet_performance_mode_begin = _Signal(code='start_performance_mode', namespace='pyplanet')
+pyplanet_performance_mode_end	= _Signal(code='end_performance_mode', namespace='pyplanet')
+
 _SignalManager.register_signal([
 	pyplanet_start_before, pyplanet_start_after, pyplanet_start_gbx_before ,pyplanet_start_gbx_after,
-	pyplanet_start_db_before, pyplanet_start_db_after, pyplanet_start_apps_before, pyplanet_start_apps_after
+	pyplanet_start_db_before, pyplanet_start_db_after, pyplanet_start_apps_before, pyplanet_start_apps_after,
+	pyplanet_performance_mode_begin, pyplanet_performance_mode_end
 ])


### PR DESCRIPTION
To improve performance with bigger amount of players, the performance mode will kick in when a certain amount of players is reached (setting). The widgets for Local Records and Dedimania are already using this to determine whether to show the top X records or personalized. Closes #135.