### PR TITLE
Only handle player info change if still online.

### DIFF
--- a/pyplanet/contrib/player/manager.py
+++ b/pyplanet/contrib/player/manager.py
@@ -141,6 +141,9 @@ class PlayerManager(CoreContrib):
 		if not player:
 			return
 
+		if player not in self._online:
+			return
+
 		async with self._counter_lock:
 			if player.flow.is_spectator is True and not is_spectator:
 				self._spectators_count -= 1


### PR DESCRIPTION
Might solve #389.

(actually bugfix, not feature)