### PR TITLE
For players, only display personal folders when adding a map.

### DIFF
--- a/pyplanet/apps/contrib/jukebox/folders.py
+++ b/pyplanet/apps/contrib/jukebox/folders.py
@@ -97,7 +97,7 @@ class FolderManager:
 		return await Folders.objects.execute(
 			Folders.select(Folders, Player)
 				.join(Player)
-				.where((Player.login == player.login) | (Folders.public == False))
+				.where((Player.login == player.login))
 		)
 
 	async def create_folder(self, **kwargs):


### PR DESCRIPTION
Solves #499.