### PR TITLE
add support for mx map packs

### DIFF
--- a/pyplanet/apps/contrib/mx/__init__.py
+++ b/pyplanet/apps/contrib/mx/__init__.py
@@ -3,10 +3,11 @@ import os
 
 from pyplanet.apps.config import AppConfig
 from pyplanet.apps.contrib.mx.api import MXApi
-from pyplanet.apps.contrib.mx.view import MxSearchListView
 from pyplanet.apps.contrib.mx.exceptions import MXMapNotFound, MXInvalidResponse
+from pyplanet.apps.contrib.mx.view import MxSearchListView, MxPacksListView
 from pyplanet.contrib.command import Command
 from pyplanet.contrib.setting import Setting
+from collections import namedtuple
 
 logger = logging.getLogger(__name__)
 
@@ -39,17 +40,46 @@ class MX(AppConfig):  # pragma: no cover
 		)
 
 		await self.instance.command_manager.register(
+			# support backwards
+			Command(command='mx', namespace='add', target=self.add_mx_map, perms='mx:add_remote', admin=True).add_param(
+				'maps', nargs='*', type=str, required=True, help='MX ID(s) of maps to add.'),
+
+			# new mx namespace
 			Command(command='search', namespace='mx', target=self.search_mx_map, perms='mx:add_remote', admin=True),
-			Command(command='add', namespace='mx', target=self.add_mx_map, perms='mx:add_remote', admin=True)
-				.add_param('maps', nargs='*', type=str, required=True, help='MX ID(s) of maps to add.'),
-			Command(command='mx', namespace='add', target=self.add_mx_map, perms='mx:add_remote', admin=True)
-				.add_param('maps', nargs='*', type=str, required=True, help='MX ID(s) of maps to add.'),
+			Command(command='add', namespace='mx', target=self.add_mx_map, perms='mx:add_remote', admin=True).add_param(
+				'maps', nargs='*', type=str, required=True, help='MX ID(s) of maps to add.'),
+
+			# new mxpack namespace
+			Command(command='search', namespace='mxpack', target=self.search_mx_pack, perms='mx:add_remote',
+					admin=True),
+			Command(command='add', namespace='mxpack', target=self.add_mx_pack, perms='mx:add_remote', admin=True)
+				.add_param('pack', nargs='*', type=str, required=True, help='MX ID(s) of mappacks to add.'),
 		)
+
+	async def search_mx_pack(self, player, data, **kwargs):
+		self.api.key = await self.setting_mx_key.get_value()
+		window = MxPacksListView(self, player, self.api)
+		await window.display()
 
 	async def search_mx_map(self, player, data, **kwargs):
 		self.api.key = await self.setting_mx_key.get_value()
 		window = MxSearchListView(self, player, self.api)
 		await window.display()
+
+	async def add_mx_pack(self, player, data, **kwargs):
+		try:
+			pack_id = data.pack[0]
+			token = data.pack[1] if len(data.pack) == 2 else ""
+			ids = await self.api.get_pack_ids(pack_id, token)
+			mx_ids = list()
+			for obj in ids:
+				mx_ids.append(str(obj[0]))
+
+			mock = namedtuple("data", ["maps"])
+			await self.add_mx_map(player, mock(maps=mx_ids))
+		except MXMapNotFound:
+			message = '$ff0Error: Can\'t add map pack from MX, due error.'
+			await self.instance.chat(message, player)
 
 	async def add_mx_map(self, player, data, **kwargs):
 		# Make sure we update the key in the api.

--- a/pyplanet/apps/contrib/mx/view.py
+++ b/pyplanet/apps/contrib/mx/view.py
@@ -202,3 +202,163 @@ class MxSearchListView(ManualListView):
 
 		if refresh:
 			await self.refresh(self.player)
+
+
+class MxPacksListView(ManualListView):
+	title = '🔍 Search Mania-Exchange'
+
+	def __init__(self, app, player, api):
+		"""
+		:param app: App config instance.
+		:param player: Player instance.
+		:type app: pyplanet.apps.contrib.mx.app.RealMX
+		"""
+		super().__init__()
+		self.manager = app.context.ui
+		self.player = player
+		self.app = app
+		self.api = api
+
+		self.template_name = 'mx/search.xml'
+		self.response_future = asyncio.Future()
+
+		self.cache = None
+		self.has_data = False
+
+		self.search_map = None
+		self.search_author = None
+		self.provide_search = True
+
+		self.fields = [
+			{
+				'name': 'ID',
+				'index': 'mxid',
+				'sorting': True,
+				'searching': False,
+				'width': 15,
+				'type': 'label'
+			},
+			{
+				'name': 'Pack Name',
+				'index': 'name',
+				'sorting': True,
+				'searching': False,
+				'width': 55,
+				'type': 'label'
+			},
+			{
+				'name': 'Author',
+				'index': 'author',
+				'sorting': True,
+				'searching': False,
+				'width': 40,
+				'type': 'label',
+			},
+			{
+				'name': 'Video',
+				'index': 'videourl',
+				'sorting': False,
+				'searching': False,
+				'width': 25,
+				'type': 'label',
+				'safe': True
+			},
+			{
+				'name': 'Maps',
+				'index': 'mapcount',
+				'sorting': True,
+				'searching': False,
+				'width': 15,
+				'type': 'label'
+			}
+		]
+
+		self.sort_field = None
+		self.child = None
+		self.subscribe("mx_search", self.action_search)
+
+	async def get_data(self):
+		if not self.has_data:
+			# First opening, request the data.
+			await self.do_search(refresh=False)
+			self.has_data = True
+
+		return self.cache
+
+	async def get_object_data(self):
+		data = await super().get_object_data()
+		data['search_map'] = self.search_map
+		data['search_author'] = self.search_author
+		return data
+
+	async def display(self, player=None):
+		return await super().display(player or self.player)
+
+	async def get_actions(self):
+		return [
+			{
+				'name': 'Install pack',
+				'type': 'label',
+				'text': 'Install',
+				'width': 12,
+				'action': self.action_install,
+				'safe': True
+			}
+		]
+
+	async def action_install(self, user, values, map, *args, **kwargs):
+		await self.app.instance.command_manager.execute(user, '//mxpack add', str(map['mxid']))
+
+	async def action_search(self, user, action, values, *args, **kwargs):
+		self.search_map = values['map']
+		self.search_author = values['author']
+
+		if values['map'] == "Search Map...":
+			self.search_map = None
+		if values['author'] == "Search Author...":
+			self.search_author = None
+
+		await self.do_search(self.search_map, self.search_author)
+
+	async def do_search(self, name=None, username=None, refresh=True, **terms):
+		try:
+			options = {
+				"api": "on",
+				"mode": 0,
+				"limit": 100,
+			}
+
+			if name is not None:
+				options['name'] = name
+
+			if username is not None:
+				options['username'] = username
+
+			infos = await self.api.search_pack(options)
+			if len(infos) == 0:
+				raise MXMapNotFound("No results for search")
+
+		except MXMapNotFound as e:
+			message = '$f00Error requesting MX-API: Map not found!'
+			await self.app.instance.chat(message, self.player)
+			logger.debug('MX-API: Map not found: {}'.format(str(e)))
+			return None
+		except MXInvalidResponse as e:
+			message = '$f00Error requesting MX-API: Got an invalid response!'
+			await self.app.instance.chat(message, self.player)
+			logger.warning('MX-API: Invalid response: {}'.format(str(e)))
+			return None
+		self.cache = [dict(
+				mxid=_map['ID'],
+				name=_map['Name'],
+				author=_map['Username'],
+				mapcount=_map['TrackCount'],
+				typename=_map['TypeName'],
+				style=_map['StyleName'],
+				videourl="$l[{video}]Video$l".format(video=_map['VideoURL']) if len(_map['VideoURL']) > 0 else "",
+				unreleased='{}'.format(_map['Unreleased']),
+				request='{}'.format(_map['Request'])
+			) for _map in infos]
+
+		if refresh:
+			await self.refresh(self.player)


### PR DESCRIPTION
Adding new feature: `//mxpack`

you can use `//mxpack search` to graphically search packs
and `//mxpack add {ID}` to install mappack from mania-exchange.
unpublished map packs it's possible to add them using token:
`//mxpack add {ID} {TOKEN}`
