### PR TITLE
[BUGFIX] Ignore invalid checkpoint times in the best cps widget

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Apps
 * Bugfix: Using the map name from MX if the Gbx map name is not provided by MX.
 * Bugfix: Fixing issue with MX update check on Shootmania.
 * Bugfix: Show a warning when a map might fail with dedimania due to the size of the embedded blocks.
+* Bugfix: Ignore invalid checkpoint times in the best cps widget.
 
 0.7.4 (04 March 2020)
 ---------------------

--- a/pyplanet/apps/contrib/best_cps/__init__.py
+++ b/pyplanet/apps/contrib/best_cps/__init__.py
@@ -34,6 +34,11 @@ class BestCpTimes(AppConfig):
 	async def player_cp(self, player, raw, *args, **kwargs):
 		cpnm = int(raw['checkpointinlap'])
 		laptime = int(raw['laptime'])
+
+		# Ignore invalid times (cp time will be 0)
+		if laptime == 0:
+			return
+
 		pcp = PlayerCP(player, cpnm + 1, laptime)
 		if not self.best_cp_times:
 			self.best_cp_times.append(pcp)


### PR DESCRIPTION
Fixes #862 