### PR TITLE
"full" docker-compose template

### DIFF
--- a/docker-compose-templates/full/dedicated_vars.env.default
+++ b/docker-compose-templates/full/dedicated_vars.env.default
@@ -1,0 +1,20 @@
+#Maniaplanet dedicated server IDs. See: https://maniaplanet.com/account/dedicated-servers
+LOGIN=
+PASSWORD=
+
+#Maniaplanet dedicated server config.
+TITLE=TMStadium@nadeo
+TITLE_PACK_URL=https://v4.live.maniaplanet.com/ingame/public/titles/download/TMStadium@nadeo.Title.Pack.gbx
+TITLE_PACK_FILE=TMStadium@nadeo.Title.Pack.gbx
+MATCH_SETTINGS=MatchSettings/default.txt
+SERVER_NAME=DefaultName
+
+#Database config. Changes here will only be applied on the database container. 
+#This can be changed in "pyplanet" volume "/app/server/settings/base.py", file app.py, l56. <<-- That will be improve in the futur, it's on the TODO list.
+MYSQL_USER=pyplanet
+MYSQL_PASSWORD=pyplanet
+MYSQL_DATABASE=pyplanet
+MYSQL_ROOT_PASSWORD=
+
+#SFTP password of maniaplanet user. By default listening 0.0.0.0:8154 on your host.
+SFTP_PASSWORD=

--- a/docker-compose-templates/full/docker-compose.yml
+++ b/docker-compose-templates/full/docker-compose.yml
@@ -1,0 +1,84 @@
+#Maintained by Célian "celianvdb" VAN DER BIEST <me@celianvdb.fr>
+version: '3'
+services:
+  controller:
+    image: pyplanet/controller
+    restart: always
+    depends_on:
+      - dedicated
+      - db
+    volumes:
+      - pyplanet:/app/server/
+      - maniaplanet:/app/dedicated/
+    networks:
+      - back
+
+  dedicated:
+    image: pyplanet/maniaplanet-dedicated
+    restart: always
+    env_file: ./dedicated_vars.env
+    volumes:
+      - maniaplanet:/app/dedicated
+      - maniaplanet_configs:/app/dedicated-configs
+    networks:
+      - back
+      - front
+    expose:
+      - "5000"
+    ports:
+      - "2350:2350"
+      - "2350:2350/udp"
+      - "3450:3450"
+      - "3450:3450/udp"
+
+  db:
+    image: mariadb:latest
+    restart: always
+    env_file: ./dedicated_vars.env
+    environment:
+      MYSQL_INITDB_SKIP_TZINFO: 1
+    volumes:
+      - database:/var/lib/mysql/
+    networks:
+      - back
+    expose:
+      - "3306"
+
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+
+  pma:
+    image: phpmyadmin/phpmyadmin
+    restart: always
+    depends_on:
+      - db
+    env_file: ./dedicated_vars.env   
+    networks:
+      - front
+      - back
+    ports:
+      - "8080:80"
+      
+  sftp:
+    image: atmoz/sftp
+    restart: always
+    env_file: ./dedicated_vars.env
+    volumes:
+      - maniaplanet:/home/maniaplanet/dedicated
+      - pyplanet:/home/maniaplanet/pyplanet
+    networks:
+      - front
+    ports:
+      - "8022:22"
+
+    command: ["sh", "-c", "./entrypoint maniaplanet:$${SFTP_PASSWORD}:1000"]
+    
+volumes: 
+  maniaplanet:
+  maniaplanet_configs:
+  pyplanet:
+  database:
+
+networks: 
+  frontend:
+  backend:
+

--- a/docker-compose-templates/full/docker-compose.yml
+++ b/docker-compose-templates/full/docker-compose.yml
@@ -79,6 +79,6 @@ volumes:
   database:
 
 networks: 
-  frontend:
-  backend:
+  front:
+  back:
 


### PR DESCRIPTION
## Motivation or cause

https://github.com/PyPlanet/PyPlanet/issues/793

## Change description

The "full" docker-compose template allow docker user to start pyplanet, maniaplanet, mariadb, pma and sftp in one line.

## Checklist of pull request

Need to add a docker part on the documentation. https://github.com/PyPlanet/PyPlanet/issues/794