### PR TITLE
Allow custom length in Live Rankings widget

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Apps
 * Improvement: Move the checkpoint difference widgets a bit higher so it doesn't block the view so much (sector_times app).
 * Improvement: Improve the retry mechanism of Dedimania during connection issues.
 * Improvement: Make sure that updated maps with MX will reappear in the map folders.
+* Improvement: Switch the dedimania widget with liveranking and currentcps widgets if dedimania widget is not visible.
 
 * Bugfix: Using the map name from MX if the Gbx map name is not provided by MX.
 * Bugfix: Fixing issue with MX update check on Shootmania.

--- a/pyplanet/apps/contrib/currentcps/__init__.py
+++ b/pyplanet/apps/contrib/currentcps/__init__.py
@@ -18,6 +18,8 @@ class CurrentCPs(AppConfig):
 		self.widget = None
 		self.player_cps = []  # Holds the sorted PlayerCP objects (these get displayed by the widget)
 
+		self.dedimania_enabled = False
+
 	# FOR TESTING ONLY, DO NOT USE IN PRODUCTION CODE
 	def fill_test_cps(self):
 		"""
@@ -51,12 +53,14 @@ class CurrentCPs(AppConfig):
 		self.context.signals.listen(tm_signals.finish, self.player_finish)
 		self.context.signals.listen(mp_signals.player.player_connect, self.player_connect)
 		self.context.signals.listen(mp_signals.player.player_disconnect, self.player_disconnect)
-		self.context.signals.listen(mp_signals.map.map_start__end, self.map_end)
+		self.context.signals.listen(mp_signals.map.map_start__end, self.map_start)
 		self.context.signals.listen(mp_signals.player.player_enter_spectator_slot, self.player_enter_spec)
 
 		# Make sure we move the rounds_scores and other gui elements.
 		self.instance.ui_manager.properties.set_attribute('round_scores', 'pos', '-126.5 87. 150.')
 		self.instance.ui_manager.properties.set_attribute('multilap_info', 'pos', '107., 88., 5.')
+
+		self.dedimania_enabled = ('dedimania' in self.instance.apps.apps and 'dedimania' not in self.instance.apps.unloaded_apps)
 
 		self.widget = CPWidgetView(self)
 		# await self.widget.display()
@@ -110,8 +114,9 @@ class CurrentCPs(AppConfig):
 		self.current_cps.pop(player.login, None)
 		await self.update_view()
 
-	# When the map ends
-	async def map_end(self, *args, **kwargs):
+	# When the map start (end of event)
+	async def map_start(self, *args, **kwargs):
+		self.dedimania_enabled = ('dedimania' in self.instance.apps.apps and 'dedimania' not in self.instance.apps.unloaded_apps)
 		self.current_cps.clear()  # Clear the current CPs when the map ends
 		await self.update_view()
 

--- a/pyplanet/apps/contrib/currentcps/view.py
+++ b/pyplanet/apps/contrib/currentcps/view.py
@@ -70,6 +70,10 @@ class CPWidgetView(TimesWidgetView):
 
 		return data
 
+	async def get_context_data(self):
+		self.widget_y = 12.5 if self.app.dedimania_enabled else 70.5
+		return await super().get_context_data()
+
 	async def handle_catch_all(self, player, action, values, **kwargs):
 		logging.debug("CatchAll: " + player.login + ": " + action)
 		if str(action).startswith('spec_'):

--- a/pyplanet/apps/contrib/dedimania/views.py
+++ b/pyplanet/apps/contrib/dedimania/views.py
@@ -9,7 +9,7 @@ from pyplanet.utils import times
 
 class DedimaniaRecordsWidget(TimesWidgetView):
 	widget_x = -160
-	widget_y = 12.5
+	widget_y = 70.5
 	z_index = 30
 	size_x = 38
 	size_y = 55.5

--- a/pyplanet/apps/contrib/live_rankings/__init__.py
+++ b/pyplanet/apps/contrib/live_rankings/__init__.py
@@ -44,7 +44,7 @@ class LiveRankings(AppConfig):
 		self.instance.ui_manager.properties.set_visibility('round_scores', False)
 		self.instance.ui_manager.properties.set_attribute('multilap_info', 'pos', '107., 88., 5.')
 
-		self.dedimania_enabled = ('dedimania' in self.instance.apps.apps)
+		self.dedimania_enabled = ('dedimania' in self.instance.apps.apps and 'dedimania' not in self.instance.apps.unloaded_apps)
 
 		self.widget = LiveRankingsWidget(self)
 		await self.widget.display()
@@ -109,7 +109,7 @@ class LiveRankings(AppConfig):
 	async def map_start(self, map, restarted, **kwargs):
 		self.current_rankings = []
 		self.current_finishes = []
-		self.dedimania_enabled = ('dedimania' in self.instance.apps.apps)
+		self.dedimania_enabled = ('dedimania' in self.instance.apps.apps and 'dedimania' not in self.instance.apps.unloaded_apps)
 		await self.get_points_repartition()
 		await self.widget.display()
 

--- a/pyplanet/apps/contrib/live_rankings/__init__.py
+++ b/pyplanet/apps/contrib/live_rankings/__init__.py
@@ -4,6 +4,8 @@ from pyplanet.apps.contrib.live_rankings.views import LiveRankingsWidget
 from pyplanet.apps.core.trackmania import callbacks as tm_signals
 from pyplanet.apps.core.maniaplanet import callbacks as mp_signals
 
+from pyplanet.contrib.setting import Setting
+
 
 class LiveRankings(AppConfig):
 	game_dependencies = ['trackmania']
@@ -16,8 +18,18 @@ class LiveRankings(AppConfig):
 		self.points_repartition = []
 		self.current_finishes = []
 		self.widget = None
+		self.dedimania_enabled = False
+
+		self.setting_rankings_amount = Setting(
+			'rankings_amount', 'Amount of rankings to display', Setting.CAT_BEHAVIOUR, type=int,
+			description='Amount of live rankings to display (minimum: 15).',
+			default=15
+		)
 
 	async def on_start(self):
+		# Init settings.
+		await self.context.setting.register(self.setting_rankings_amount)
+
 		# Register signals
 		self.context.signals.listen(mp_signals.map.map_start, self.map_start)
 		self.context.signals.listen(mp_signals.flow.round_start, self.round_start)
@@ -31,6 +43,8 @@ class LiveRankings(AppConfig):
 		self.instance.ui_manager.properties.set_visibility('checkpoint_ranking', False)
 		self.instance.ui_manager.properties.set_visibility('round_scores', False)
 		self.instance.ui_manager.properties.set_attribute('multilap_info', 'pos', '107., 88., 5.')
+
+		self.dedimania_enabled = ('dedimania' in self.instance.apps.apps)
 
 		self.widget = LiveRankingsWidget(self)
 		await self.widget.display()
@@ -95,6 +109,7 @@ class LiveRankings(AppConfig):
 	async def map_start(self, map, restarted, **kwargs):
 		self.current_rankings = []
 		self.current_finishes = []
+		self.dedimania_enabled = ('dedimania' in self.instance.apps.apps)
 		await self.get_points_repartition()
 		await self.widget.display()
 

--- a/pyplanet/apps/contrib/live_rankings/views.py
+++ b/pyplanet/apps/contrib/live_rankings/views.py
@@ -129,6 +129,13 @@ class LiveRankingsWidget(TimesWidgetView):
 		return list_records
 
 	async def get_context_data(self):
+		# Determine the Y of the widget. It should be placed under the dedimania widget if it's enabled.
+		# Otherwise, take the space below the server information on the top left.
+		self.widget_y = 12.5 if self.app.dedimania_enabled else 70.5
+		self.record_amount = await self.app.setting_rankings_amount.get_value()
+		if self.record_amount < 15:
+			self.record_amount = 15
+
 		current_script = await self.app.instance.mode_manager.get_current_script()
 		if 'TimeAttack' in current_script:
 			self.format_times = True


### PR DESCRIPTION
Switched location of Dedimania and Live Rankings widget, to allow for longer Live Rankings list.
Live Rankings widget will take the place of the Dedimania one if Dedimania is not enabled.

Closes #875.