### PR TITLE
Add Dockerfile and it's config file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.8
+LABEL maintainer="Tom Valk <tomvalk@lt-box.info>"
+ENV PROJECT_ROOT /app
+ENV IS_DOCKER 1
+
+# Create maniaplanet user/group
+RUN addgroup --gid 1000 maniaplanet && \
+    adduser -u 1000 --group maniaplanet --system
+
+RUN apt-get -q update \
+&& apt-get install -y build-essential libssl-dev libffi-dev zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create project root.
+RUN mkdir -p $PROJECT_ROOT
+WORKDIR $PROJECT_ROOT
+COPY docker_base.py $PROJECT_ROOT/base.py
+RUN chown -R maniaplanet:maniaplanet $PROJECT_ROOT
+
+# Install PyPlanet.
+RUN pip install pyplanet --upgrade	
+
+USER maniaplanet
+
+# Init project.
+RUN pyplanet init_project server
+WORKDIR $PROJECT_ROOT/server/
+RUN cp ../base.py $PROJECT_ROOT/server/settings/base.py
+
+VOLUME $PROJECT_ROOT/server/
+
+ENTRYPOINT [ "./manage.py" ]
+CMD [ "start", "--pool=default", "--settings=settings" ]

--- a/docker_base.py
+++ b/docker_base.py
@@ -1,0 +1,114 @@
+"""
+This file contains the basic settings and overrides the default ones that are defined in the core.
+Documentation: http://pypla.net/
+
+If you want to use other configuration methods like YAML or JSON files, take a look at http://pypla.net/ and head to the
+configuration pages.
+"""
+import os
+
+# Set the root_path to the root of our project.
+ROOT_PATH = os.path.dirname(os.path.dirname(__file__))
+
+# Set the temporary location for the project.
+TMP_PATH = os.path.join(ROOT_PATH, 'tmp')
+
+# Create temporary folder if not exists.
+if not os.path.exists(TMP_PATH):
+	os.mkdir(TMP_PATH)
+
+# Enable debug mode to get verbose output, not report any errors and dynamically use the DEBUG in your code
+# for extra verbosity of logging/output.
+DEBUG = bool(os.environ.get('PYPLANET_DEBUG', False))
+
+# Add your pools (the controller instances per dedicated here) or leave as it is to use a single instance only.
+POOLS = [
+	'default'
+]
+
+# Owners are logins of the server owners, the owners always get *ALL* the permissions in the system.
+OWNERS = {
+	'default': [
+		os.getenv('MANIAPLANET_OWNER_LOGIN', '')
+	]
+}
+
+# Allow self-upgrading the installation. Disable on shared servers with one installation (hosting environment)!
+SELF_UPGRADE = False
+
+# Databases configuration holds an dictionary with information of the database backend.
+# Please refer to the documentation for all examples. http://pypla.net/
+
+if os.environ.get('MYSQL_HOST') is not None:
+	DATABASES = {
+		'default': {
+			'ENGINE': 'peewee_async.MySQLDatabase',
+			'NAME': os.getenv('MYSQL_DATABASE', 'pyplanet'),
+			'OPTIONS': {
+				'host': os.getenv('MYSQL_HOST', 'db'),
+				'user': os.getenv('MYSQL_USER', 'pyplanet'),
+				'password': os.getenv('MYSQL_PASSWORD', 'pyplanet'),
+				'charset': 'utf8mb4',
+			}
+		}
+	}
+elif os.environ.get('POSTGRES_HOST') is not None:
+        DATABASES = {
+                'default': {
+                        'ENGINE': 'peewee_async.PostgresqlDatabase',
+                        'NAME': os.getenv('POSTGRES_DB', 'pyplanet'),
+                        'OPTIONS': {
+                                'host': os.getenv('POSTGRES_HOST', 'db'),
+                                'user': os.getenv('POSTGRES_USER', 'pyplanet'),
+                                'password': os.getenv('POSTGRES_PASSWORD', 'pyplanet'),
+                                'autocommit': 'True',
+                        }
+                }
+        }
+
+# Dedicated configuration holds the different dedicated servers that the instances will run on including the names of
+# the instances.
+DEDICATED = {
+	'default': {
+		'HOST': os.getenv('MANIAPLANET_HOST', 'dedicated'),
+		'PORT': os.getenv('MANIAPLANET_PORT', '5000'),
+		'USER': os.getenv('MANIAPLANET_USER', 'SuperAdmin'),
+		'PASSWORD': os.getenv('MANIAPLANET_PASSWORD', 'SuperAdmin'),
+	}
+}
+
+# Map configuration is a set of configuration options related to match settings etc.
+# Matchsettings filename.
+MAP_MATCHSETTINGS = {
+	'default': 'maplist.txt',
+}
+
+# Blacklist file is managed by the dedicated server and will be loaded and writen to by PyPlanet once a
+# player gets blacklisted. The default will be the filename Maniaplanet always uses and is generic.
+BLACKLIST_FILE = {
+	'default': 'blacklist.txt'
+}
+
+# The storage configuration contains the same instance mapping of the dedicated servers and is used
+# to access the filesystem on the dedicated server location.
+# Please refer to the documentation for more information. http://pypla.net/
+STORAGE = {
+	'default': {
+		'DRIVER': 'pyplanet.core.storage.drivers.local.LocalDriver',
+		'OPTIONS': {},
+	}
+}
+
+# Define any cache backends that can be used by the core and the plugins to cache data.
+# This is not yet implemented. As soon as it's implemented you can activate it with the documentation, available on
+# http://pypla.net/
+# CACHE = {
+# 	'default': {
+#
+# 	}
+# }
+
+# Songs is a list of URLs to .ogg files of songs to be played by the music server.
+SONGS = {
+	'default': []
+}


### PR DESCRIPTION
## Motivation or cause

Reorganization of docker stuff in PyPlanet. After this pull request and https://github.com/PyPlanet/docker/pull/5, docker stuff needed to deploy infrastructure will be in the docker repo and only the Dockerfile of pyplanet will be in the pyplanet repo.

## Change description

* Move the dockerfile and it's config file from docker repo to the main one.
* Upgrade to python 3.8
* Improve configuration of the image. More infos here : https://github.com/PyPlanet/docker/blob/f4891c662c92b18cd7946f9d84e66e136739ed7b/README.md

## Checklist of pull request

Need to add a docker part on the documentation. https://github.com/PyPlanet/PyPlanet/issues/794
Need to update https://hub.docker.com/r/pyplanet/controller/
