### PR TITLE
Fix for Showing Delete icon for non-admins

### DIFF
--- a/pyplanet/apps/contrib/admin/map.py
+++ b/pyplanet/apps/contrib/admin/map.py
@@ -79,10 +79,15 @@ class MapAdmin:
 				.add_param('seconds', required=False, type=int, help='Extend the TA limit with given seconds.'),
 		)
 
-		# If jukebox app is loaded, register the map actions.
+				# If jukebox app is loaded, register the map actions.
+		
 		if 'jukebox' in self.instance.apps.apps:
-			from pyplanet.apps.contrib.jukebox.views import MapListView
-			MapListView.add_action(self.list_action_remove, 'Delete', '&#xf1f8;')
+				from pyplanet.apps.contrib.jukebox.views import MapListView
+				for player in self.app.instance.player_manager.online:
+					if not await self.app.instance.permission_manager.has_permission(player, 'admin:remove_map'):
+							return
+					else:
+						MapListView.add_action(self.list_action_remove, 'Delete', '&#xf1f8;')
 
 	async def list_action_remove(self, player, values, map_dictionary, view, **kwargs):
 		# Check permission.


### PR DESCRIPTION
Fix for #930 on /list where it removes the icon of Delete.

## Motivation or cause

Show for non admin players without the Delete Icon

## Change description

Check for players online that can't/haven't permission to remove maps.

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.

Please leave a comment here if your pull need any updates for the docs or tests.

### Additional Comments (optional)

{Please write here}
