### PR TITLE
Fix for Folders in /list

### DIFF
--- a/pyplanet/apps/contrib/jukebox/views.py
+++ b/pyplanet/apps/contrib/jukebox/views.py
@@ -262,11 +262,12 @@ class MapListView(ManualListView):
 		await self.app.add_to_jukebox(player, await self.app.instance.map_manager.get_map(map_info['uid']))
 
 	async def action_folders(self, player, values, **kwargs):
-		await self.app.folder_manager.display_folder_list(player)
+		if player.level > player.LEVEL_PLAYER:
+			await self.app.folder_manager.display_folder_list(player)
 
 	async def action_advanced(self, player, values, **kwargs):
 		if len(self.app.instance.map_manager.maps) > 500:
-			if self.player.level == 0:
+			if player.level == 0:
 				await self.app.instance.chat(
 					'This server contains 500+ maps. Advanced map list only activated for admins!', self.player
 				)


### PR DESCRIPTION
When pressing Folders next to advanced list it will not work for non-admins.

Past two pull requests are almost the same as issue #930.

There is no check for admins or players so it shows Admin Icons to players.