### PR TITLE
cp_diff_next Fix for Laps

### DIFF
--- a/pyplanet/apps/contrib/sector_times/templates/cp_diff_next.Script.Txt
+++ b/pyplanet/apps/contrib/sector_times/templates/cp_diff_next.Script.Txt
@@ -36,6 +36,9 @@ Void UpdateInterface() {
   if (GUIPlayer != Null && GUIPlayer.RaceWaypointTimes.existskey(CurrentCheckpoint - 1)) {
     CurrentCheckpointTime = GUIPlayer.RaceWaypointTimes[CurrentCheckpoint - 1];
   }
+  if (GUIPlayer != Null && GUIPlayer.LapWaypointTimes.existskey(CurrentCheckpoint - 1)) {
+    CurrentCheckpointTime = GUIPlayer.LapWaypointTimes[CurrentCheckpoint - 1];
+  }
   if (CurrentCheckpointTime == -1 && CurrentLapScore > 0) {
     CurrentCheckpointTime = CurrentLapScore;
   }
@@ -168,23 +171,23 @@ main() {
     }
     if (GUIPlayer != Null){
       declare wayPointTimesCount = GUIPlayer.RaceWaypointTimes.count;
+	  declare LapwayPointTimesCount = GUIPlayer.LapWaypointTimes.count; // Race with Multilaps
       declare Boolean IsSpectating = GUIPlayer != InputPlayer;
-	  //New cp or reset
+	  //New cp or reset on Race
       if (LastCpCount != wayPointTimesCount) {
 		//reset
-        if (wayPointTimesCount == 0){
+        if (wayPointTimesCount == 0) {
           CurrentCheckpointScores = Integer[];
           CurrentCheckpoint = 0;
           UpdateInterface();
-          HideDiff();
         } else { //new cp
           if (GUIPlayer.StartTime >= 0) {
             CurrentCheckpoint = wayPointTimesCount;
             CurrentCheckpointScores.add(GUIPlayer.RaceWaypointTimes[wayPointTimesCount - 1]);
-			      ShowDiff();
             UpdateInterface();
 
-            if (CurrentCheckpoint >= TotalCheckpoints) { // end of lap (TODO handle multilap)
+
+            if (CurrentCheckpoint >= TotalCheckpoints) {
               CurrentCheckpoint = 0;
               if (! IsSpectating && (BestScore <= 0 || GUIPlayer.RaceWaypointTimes[wayPointTimesCount - 1] < BestScore) && CurrentCheckpointScores.count == TotalCheckpoints) {
                 BestScore = GUIPlayer.RaceWaypointTimes[wayPointTimesCount - 1];
@@ -196,6 +199,33 @@ main() {
           }
         }
         LastCpCount = wayPointTimesCount;
+      }
+	//New cp or reset on Race
+      if (LastCpCount != LapwayPointTimesCount) {
+		//reset
+        if (LapwayPointTimesCount == 0) {
+          CurrentCheckpointScores = Integer[];
+          CurrentCheckpoint = 0;
+          UpdateInterface();
+        } else { //new cp
+          if (GUIPlayer.StartTime >= 0) {
+            CurrentCheckpoint = LapwayPointTimesCount;
+            CurrentCheckpointScores.add(GUIPlayer.LapWaypointTimes[LapwayPointTimesCount - 1]);
+            UpdateInterface();
+
+
+            if (CurrentCheckpoint >= TotalCheckpoints) { // end of lap (TODO handle multilap)
+              CurrentCheckpoint = 0;
+              if (! IsSpectating && (BestScore <= 0 || GUIPlayer.LapWaypointTimes[LapwayPointTimesCount - 1] < BestScore) && CurrentCheckpointScores.count == TotalCheckpoints) {
+                BestScore = GUIPlayer.LapWaypointTimes[LapwayPointTimesCount - 1];
+                BestSource = "Round";
+                BestCheckpoints = CurrentCheckpointScores;
+              }
+              CurrentCheckpointScores = Integer[];
+            }
+          }
+        }
+        LastCpCount = LapwayPointTimesCount;
       }
     }
     yield;


### PR DESCRIPTION
TM2020 Fix for Laps/MultiLaps.

Source is this code:

```
Integer GetCurRaceRank(CSmPlayer _Owner, Integer _CheckpointIndex, Integer _Time, Boolean _IsIndependentLaps) {
	declare Rank = 1;

	if (_Owner != Null && _Time >= 0 && _CheckpointIndex >= 0) {
		foreach (Player in Players) {
			if (Player.Id != _Owner.Id) {
				if (
					_IsIndependentLaps &&
					_CheckpointIndex < Player.LapWaypointTimes.count &&
					Player.LapWaypointTimes[_CheckpointIndex] >= 0 &&
					_Time > Player.LapWaypointTimes[_CheckpointIndex]
				) {
					Rank += 1;
				} else if (
					!_IsIndependentLaps &&
					_CheckpointIndex < Player.RaceWaypointTimes.count &&
					Player.RaceWaypointTimes[_CheckpointIndex] >= 0 &&
					_Time > Player.RaceWaypointTimes[_CheckpointIndex]
				) {
					Rank += 1;
				}
			}
		}
	}

	return Rank;
```

This is used in the Checkpoint Widgets of Nadeo so multilaps/start/finishes should work.

Tested it in TA/Lap/Rounds no error.