### PR TITLE
Update for //reboot

### DIFF
--- a/pyplanet/apps/contrib/admin/pyplanet.py
+++ b/pyplanet/apps/contrib/admin/pyplanet.py
@@ -23,5 +23,9 @@ class PyPlanetAdmin:
 		)
 
 	async def reboot_pool(self, player, data, **kwargs):
-		exit(50)
-		os.execl(sys.executable, sys.executable, *sys.argv)
+		if os.name == 'nt':
+			os._exit(50)
+			os.execl(sys.executable, sys.executable, *sys.argv)
+		else:
+			exit(50)
+		

--- a/pyplanet/apps/contrib/admin/pyplanet.py
+++ b/pyplanet/apps/contrib/admin/pyplanet.py
@@ -1,6 +1,8 @@
 """
 Player Admin methods and functions.
 """
+import os
+
 from pyplanet.contrib.command import Command
 
 
@@ -22,3 +24,4 @@ class PyPlanetAdmin:
 
 	async def reboot_pool(self, player, data, **kwargs):
 		exit(50)
+		os.execl(sys.executable, sys.executable, *sys.argv)


### PR DESCRIPTION
This reboots pyplanet after 50 seconds and not kills it. (Windows)


## Motivation or cause

//reboot did after 50 seconds nothing, and did not restart pyplanet

## Change description

//reboot reboots the pool after 50 seconds and pyplanet gets a restart

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.