### PR TITLE
Fix for issue #1085

### DIFF
--- a/pyplanet/apps/contrib/jukebox/views.py
+++ b/pyplanet/apps/contrib/jukebox/views.py
@@ -437,7 +437,9 @@ class FolderMapListView(MapListView):
 		await map_in_folder.save()
 
 		await show_alert(player, 'Map has been added to the folder!', 'sm')
-		await self.display(player)
+		view = FolderMapListView(self.folder_manager, self.folder_code, player)
+		await view.refresh(player=player)
+		return view
 
 	async def action_rename(self, player, values, **kwargs):
 		new_name = await ask_input(
@@ -451,7 +453,9 @@ class FolderMapListView(MapListView):
 		if self.folder_info and 'name' in self.folder_info:
 			self.folder_info['name'] = new_name
 
-		await self.display(player)
+		view = FolderMapListView(self.folder_manager, self.folder_code, player)
+		await view.refresh(player=player)
+		return view
 
 
 class FolderListView(ManualListView):

--- a/pyplanet/apps/contrib/jukebox/views.py
+++ b/pyplanet/apps/contrib/jukebox/views.py
@@ -382,7 +382,9 @@ class FolderMapListView(MapListView):
 		await self.folder_manager.remove_map_from_folder(self.folder_instance.id, map_dictionary['id'])
 
 		# Refresh list.
-		await self.refresh(player)
+		view = FolderMapListView(self.folder_manager, self.folder_code, player)
+		await view.refresh(player=player)
+		return view
 
 	async def get_buttons(self):
 		buttons = await super().get_buttons()


### PR DESCRIPTION
Fix for issue #1085 which only removed the map from mapinfolder table but it wasn't shown in the manialink

## Motivation or cause

Seems to be a subclass of MapListView so you need to recall the subclass and make a refresh call on it.

## Change description

`# Refresh list.
		view = FolderMapListView(self.folder_manager, self.folder_code, player)
		await view.refresh(player=player)
		return view`

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.

Please leave a comment here if your pull need any updates for the docs or tests.

### Additional Comments (optional)
