### PR TITLE
Only display MX award widget to non-spectating players.

### DIFF
--- a/pyplanet/apps/contrib/mx/__init__.py
+++ b/pyplanet/apps/contrib/mx/__init__.py
@@ -95,7 +95,10 @@ class MX(AppConfig):  # pragma: no cover
 			mx_info = await self.api.map_info(self.instance.map_manager.current_map.uid)
 			if mx_info and len(mx_info) >= 1:
 				self.award_widget.mx_id = mx_info[0][0]
-				await self.award_widget.display()
+
+				# Only display the award widget to the playing players.
+				play_logins = [p.login for p in self.instance.player_manager.online if not p.flow.is_spectator]
+				await self.award_widget.display(player_logins=play_logins)
 
 	async def podium_end(self, **kwargs):
 		await self.award_widget.hide()


### PR DESCRIPTION
For #1121 & #1119.