### PR TITLE
Set toolbar commands on start instead of on init, to allow game initialization.

### DIFF
--- a/pyplanet/apps/core/pyplanet/toolbar.py
+++ b/pyplanet/apps/core/pyplanet/toolbar.py
@@ -41,6 +41,7 @@ class ToolbarComponent:
 		)
 
 		self.app.context.signals.listen(mp_signals.player.player_connect, self.player_connect)
+		await self.widget.on_start()
 
 		if await self.setting_display_toolbar.get_value():
 			await self.widget.display()

--- a/pyplanet/apps/core/pyplanet/views/toolbar.py
+++ b/pyplanet/apps/core/pyplanet/views/toolbar.py
@@ -17,6 +17,7 @@ class ToolbarView(TemplateView):
 		self.app = app
 		self.manager = self.app.context.ui
 
+	async def on_start(self):
 		self.commands = {
 			'bar_button_list': '/list',
 			'bar_button_mf': '/mf',
@@ -40,4 +41,5 @@ class ToolbarView(TemplateView):
 	async def handle_catch_all(self, player, action, values, **kwargs):
 		if action not in self.commands:
 			return
+
 		await self.app.instance.command_manager.execute(player, self.commands[action])


### PR DESCRIPTION
The game information is not yet available on init of the toolbar component, therefore the wrong command will be linked for the map info button. Instead, set the commands on start, as game information is available by then.

Fixes #1171.