### PR TITLE
Fix checkpoint counting for TM2020. (#1118)

### DIFF
--- a/pyplanet/apps/contrib/sector_times/templates/cp_diff_next.Script.Txt
+++ b/pyplanet/apps/contrib/sector_times/templates/cp_diff_next.Script.Txt
@@ -112,27 +112,26 @@ Void ShowDiff() {
   Sector_CPTime_Frame.Show();
 }
 Integer GetCPCount() {
-	declare Integer count;
-	declare Ident[][Integer] orders;
-
-	foreach(Landmark in MapLandmarks) {
-		if ( (Landmark.Waypoint != Null && (Landmark.Waypoint.IsFinish || Landmark.Waypoint.IsMultiLap)) || Landmark.Tag == "Spawn") {
-			continue;
-		}
-		if(orders.existskey(Landmark.Order)) {
-			orders[Landmark.Order].add(Landmark.MarkerId);
-		}
-		else {
-			orders[Landmark.Order] = [Landmark.MarkerId];
-		}
-	}
-	if(orders.count == 1 && orders.existskey(0)) { // No linked cp in the map
-		count = orders[0].count;
-	}
-	else {
-		count = orders.count;
-	}
-	return count + 1; // +1 for ending
+  declare Integer count = 0;
+  declare Ident[][Integer] orders;
+  foreach(Landmark in MapLandmarks) {
+    if ((Landmark.Waypoint != Null && (Landmark.Waypoint.IsFinish || Landmark.Waypoint.IsMultiLap)) || Landmark.Tag == "Spawn") {
+      continue;
+    }
+    if (Landmark.Tag == "LinkedCheckpoint") {
+      if(orders.existskey(Landmark.Order)) {
+        orders[Landmark.Order].add(Landmark.MarkerId);
+      }
+      else {
+        orders[Landmark.Order] = [Landmark.MarkerId];
+      }
+    }
+    else {
+      count += 1;
+    }
+  }
+  count += orders.count;
+  return count + 1; // +1 for ending
 }
 main() {
 

--- a/pyplanet/apps/contrib/sector_times/templates/sector_times_next.Script.Txt
+++ b/pyplanet/apps/contrib/sector_times/templates/sector_times_next.Script.Txt
@@ -111,27 +111,26 @@ Integer[] ParseCheckpoints(Text RawInput) {
 }
 
 Integer GetCPCount() {
-	declare Integer count;
-	declare Ident[][Integer] orders;
-
-	foreach(Landmark in MapLandmarks) {
-		if ( (Landmark.Waypoint != Null && (Landmark.Waypoint.IsFinish || Landmark.Waypoint.IsMultiLap)) || Landmark.Tag == "Spawn") {
-			continue;
-		}
-		if(orders.existskey(Landmark.Order)) {
-			orders[Landmark.Order].add(Landmark.MarkerId);
-		}
-		else {
-			orders[Landmark.Order] = [Landmark.MarkerId];
-		}
-	}
-	if(orders.count == 1 && orders.existskey(0)) { // No linked cp in the map
-		count = orders[0].count;
-	}
-	else {
-		count = orders.count;
-	}
-	return count + 1; // +1 for ending
+  declare Integer count = 0;
+  declare Ident[][Integer] orders;
+  foreach(Landmark in MapLandmarks) {
+    if ((Landmark.Waypoint != Null && (Landmark.Waypoint.IsFinish || Landmark.Waypoint.IsMultiLap)) || Landmark.Tag == "Spawn") {
+      continue;
+    }
+    if (Landmark.Tag == "LinkedCheckpoint") {
+      if(orders.existskey(Landmark.Order)) {
+        orders[Landmark.Order].add(Landmark.MarkerId);
+      }
+      else {
+        orders[Landmark.Order] = [Landmark.MarkerId];
+      }
+    }
+    else {
+      count += 1;
+    }
+  }
+  count += orders.count;
+  return count + 1; // +1 for ending
 }
 main() {
   // Access the local + dedimania variables. TODO: Implement this in the local + dedi widgets.
@@ -176,9 +175,9 @@ main() {
     if (GUIPlayer != Null){
       declare wayPointTimesCount = GUIPlayer.RaceWaypointTimes.count;
       declare Boolean IsSpectating = GUIPlayer != InputPlayer;
-	  //New cp or reset
+      //New cp or reset
       if (LastCpCount != wayPointTimesCount) {
-		//reset
+        //reset
         if (wayPointTimesCount == 0) {
           CurrentCheckpointScores = Integer[];
           CurrentCheckpoint = 0;


### PR DESCRIPTION
## Motivation or cause

When linked checkpoints appear in a map in TM2020 it causes the counter and split times to be incorrect. This is summed in the issue #1118 .

## Change description

In this pull request I reworked some of the logic in the checkpoint counter function so that it would specifically only care about the "Order" field of a checkpoint if the Tag was "LinkedCheckpoint". To confirm that the tag must be "LinkedCheckpoint" I went into the editor and tried to assign a different tag name to checkpoint but it wouldn't let me.

Prior to this change the count of checkpoints was wrong because when linked checkpoints exist in map the counting considers all unlinked checkpoints as one linked group (with Order=0).
Following this correction to checkpoint counting the split times are also working properly.
I tested these changes with a multitude of maps including (but not limited to) the maps listed in issue #1118.

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.

Please leave a comment here if your pull need any updates for the docs or tests.

### Additional Comments (optional)

While making these changes I noticed these files had mixed tab and spaces for indentation. The additional whitespace changes to files were me converting the tabs to spaces.
