### PR TITLE
discord API returning correct number of online users in a server

### DIFF
--- a/docs/source/apps/contrib/ads.rst
+++ b/docs/source/apps/contrib/ads.rst
@@ -49,7 +49,7 @@ Command:
 Parameters:
   None.
 Functionality:
-  Displays the number of users and bots on the server.
+  Displays the number of users on the server.
 Required permission:
   None.
 

--- a/pyplanet/apps/contrib/ads/__init__.py
+++ b/pyplanet/apps/contrib/ads/__init__.py
@@ -204,7 +204,7 @@ class Ads(AppConfig):
 			if users:
 				join_url_link = '$l[' + self.discord_join_url + ']Join our Discord$l! '
 				message = '$ff0$i{}There are currently {} users online.' \
-					.format(join_url_link, users[0])
+					.format(join_url_link, users)
 				await self.instance.chat(message, player)
 
 	async def get_discord_users(self):
@@ -214,7 +214,7 @@ class Ads(AppConfig):
 			try:
 				async with session.get(url) as response:
 					data = await response.json()
-					return int(data["presence_count"])
+					return int(data['presence_count'])
 			except Exception as e:
 				logging.error('Error with retrieving Discord user list')
 				logging.error(e)

--- a/pyplanet/apps/contrib/ads/__init__.py
+++ b/pyplanet/apps/contrib/ads/__init__.py
@@ -203,8 +203,8 @@ class Ads(AppConfig):
 			users = await self.get_discord_users()
 			if users:
 				join_url_link = '$l[' + self.discord_join_url + ']Join our Discord$l! '
-				message = '$ff0$i{}There are currently {} users and {} bots online.' \
-					.format(join_url_link, users[0], users[1])
+				message = '$ff0$i{}There are currently {} users online.' \
+					.format(join_url_link, users[0])
 				await self.instance.chat(message, player)
 
 	async def get_discord_users(self):
@@ -214,15 +214,7 @@ class Ads(AppConfig):
 			try:
 				async with session.get(url) as response:
 					data = await response.json()
-					non_bot_users = []
-					bots = []
-					for i in data['members']:
-						if 'bot' in i:
-							bots.append(i)
-						else:
-							non_bot_users.append(i)
-					online_users = len(non_bot_users)
-					return [int(online_users), int(len(bots))]
+					return int(data["presence_count"])
 			except Exception as e:
 				logging.error('Error with retrieving Discord user list')
 				logging.error(e)


### PR DESCRIPTION
## Motivation or cause

Fixes https://github.com/PyPlanet/PyPlanet/issues/1208. The discord API request returns weird values (100 users online, 0 bots). This is due to changes in the API since the original implementation. The `members` object of the `wiget.json` is now limited to a max of 100, so we cannot accurately infer the user and bot counts from the reponse. This PR aims reinstate the original functionality as far as is possible with the current guild API.

Reference: https://discord.com/developers/docs/resources/guild#guild-widget-object

## Change description

Instead of counting the members, only the `presence_count` is now evaluated, giving an accurate number of online users.

I have updated the docs accordingly.
