### PR TITLE
Fixed (T)MX status view + retrieval of TMX IDs for existing maps

### DIFF
--- a/pyplanet/apps/contrib/mx/view.py
+++ b/pyplanet/apps/contrib/mx/view.py
@@ -530,7 +530,7 @@ class MxStatusListView(ManualListView):
 					action_update = True
 
 			action_update_content = '🔁 Update' if action_update else '          -'
-			items.append({'map_id': item.id, 'index': item.mx_id, 'map_name': item.name, 'version_match': version_match, 'version_match_order': version_match_order,
+			items.append({'map_id': item.id, 'index': int(item.mx_id), 'map_name': item.name, 'version_match': version_match, 'version_match_order': version_match_order,
 				'mx_version': mx_version_date, 'action_update': action_update, 'action_update_content': action_update_content})
 
 		# Initially sort the maps based on the 'version_match_order': New version -> Not on MX -> Up-to-date.

--- a/pyplanet/apps/contrib/mx/view.py
+++ b/pyplanet/apps/contrib/mx/view.py
@@ -404,7 +404,7 @@ class MxStatusListView(ManualListView):
 				'index': 'index',
 				'sorting': True,
 				'searching': True,
-				'width': 15,
+				'width': 18,
 				'type': 'label'
 			},
 			{
@@ -412,15 +412,7 @@ class MxStatusListView(ManualListView):
 				'index': 'map_name',
 				'sorting': True,
 				'searching': True,
-				'width': 91.5,
-				'type': 'label'
-			},
-			{
-				'name': 'On Server',
-				'index': 'updated_on_server',
-				'sorting': True,
-				'searching': False,
-				'width': 33,
+				'width': 114.5,
 				'type': 'label'
 			},
 			{
@@ -428,7 +420,7 @@ class MxStatusListView(ManualListView):
 				'index': 'mx_version',
 				'sorting': True,
 				'searching': False,
-				'width': 33,
+				'width': 40,
 				'type': 'label'
 			},
 			{
@@ -517,7 +509,7 @@ class MxStatusListView(ManualListView):
 			action_update = False
 
 			# Get MX information for the map (gets None if it couldn't be found).
-			mx_map = next((mx_map_info for mx_map_info in mx_maps_info if mx_map_info[0] == item.mx_id), None)
+			mx_map = next((mx_map_info for mx_map_info in mx_maps_info if str(mx_map_info[0]) == str(item.mx_id)), None)
 
 			if mx_map is None:
 				version_match = 'Not on {}'.format(self.app.site_short_name)
@@ -539,7 +531,7 @@ class MxStatusListView(ManualListView):
 
 			action_update_content = '🔁 Update' if action_update else '          -'
 			items.append({'map_id': item.id, 'index': item.mx_id, 'map_name': item.name, 'version_match': version_match, 'version_match_order': version_match_order,
-				'updated_on_server': item.updated_at, 'mx_version': mx_version_date, 'action_update': action_update, 'action_update_content': action_update_content})
+				'mx_version': mx_version_date, 'action_update': action_update, 'action_update_content': action_update_content})
 
 		# Initially sort the maps based on the 'version_match_order': New version -> Not on MX -> Up-to-date.
 		items.sort(key=lambda x: x['version_match_order'])

--- a/pyplanet/contrib/map/manager.py
+++ b/pyplanet/contrib/map/manager.py
@@ -145,9 +145,12 @@ class MapManager(CoreContrib):
 			db_uids = [m.uid for m in maps]
 			diff = [x for x in raw_list if x['UId'] not in db_uids]
 
-			# Update existing maps with author nicknames.
-			for existing_map in [m for m in maps if m.author_nickname is None or len(m.author_nickname) == 0]:
+			# Update existing maps with author nicknames and (T)MX-IDs.
+			for existing_map in [m for m in maps if m.author_nickname is None or len(m.author_nickname) == 0 or (m.mx_id is None and "MX" in m.file)]:
 				details = [m for m in raw_list if m['UId'] == existing_map.uid][0]
+
+				# Detect any (T)MX-id from the filename.
+				mx_id = self._extract_mx_id(details['FileName'])
 
 				author_nickname = await self.get_map_author_nickname(details)
 
@@ -155,7 +158,8 @@ class MapManager(CoreContrib):
 					details['UId'], details['FileName'], details['Name'], details['Author'],
 					author_nickname=author_nickname, environment=details['Environnement'],
 					time_gold=details['GoldTime'],
-					price=details['CopperPrice'], map_type=details['MapType'], map_style=details['MapStyle']
+					price=details['CopperPrice'], map_type=details['MapType'], map_style=details['MapStyle'],
+					mx_id=mx_id,
 				)
 
 				maps = [m for m in maps if m.uid != details['UId']]

--- a/pyplanet/contrib/map/manager.py
+++ b/pyplanet/contrib/map/manager.py
@@ -54,7 +54,7 @@ class MapManager(CoreContrib):
 		self._original_ta = None
 
 		# Regular Expression to extract the MX-ID from a filename.
-		self._mx_id_regex = re.compile('(?:PyPlanet-MX\\/)([A-Z]{2})-(\\d+)\\.')
+		self._mx_id_regex = re.compile('(?:PyPlanet-MX\\/)([A-Z]{2,6})-(\\d+)\\.')
 
 	async def on_start(self):
 		self._instance.signals.listen('maniaplanet:playlist_modified', lambda: '')


### PR DESCRIPTION
These changes should fix #1216.

Removed the 'Version on server' column as this just represented the "updated_at" column of the map object, which doesn't really say what version of the map is on the server.