### PR TITLE
Fix background of list template when no provide_search

### DIFF
--- a/pyplanet/views/templates/generics/list.xml
+++ b/pyplanet/views/templates/generics/list.xml
@@ -1,5 +1,5 @@
 <frame pos="0 17" z-index="150">
-  {% if provide_search %}
+  {% if provide_search or (buttons is defined and (buttons | length > 0)) %}
     <quad pos="0 62.5" size="220 137" z-index="-50" halign="center" valign="top" style="Bgs1InRace" substyle="BgCardList"/>
   {% else %}
     <quad pos="0 62.5" size="220 127" z-index="-50" halign="center" valign="top" style="Bgs1InRace" substyle="BgCardList"/>


### PR DESCRIPTION
## Motivation or cause

This resolves #1232 .

## Change description

In list.xml template the background size is extended based on there being a search provided or buttons having more than zero elements.

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.

Please leave a comment here if your pull need any updates for the docs or tests.

### Additional Comments (optional)

This same conditional is already used in 2 other places in the same template file.
