### PR TITLE
Potential Fix for Ping Issue with Points_Added in Live Rankings

### DIFF
--- a/pyplanet/apps/contrib/live_rankings/__init__.py
+++ b/pyplanet/apps/contrib/live_rankings/__init__.py
@@ -216,18 +216,21 @@ class LiveRankings(AppConfig):
 
 			new_finish = dict(login=player.login, nickname=player.nickname, score=race_time)
 			self.current_finishes.append(new_finish)
+			self.current_finishes.sort(key=lambda x: (x['score']))
 
-			new_finish_rank = len(self.current_finishes) - 1
-			new_finish['points_added'] = self.points_repartition[new_finish_rank] \
-				if len(self.points_repartition) > new_finish_rank \
-				else self.points_repartition[(len(self.points_repartition) - 1)]
+			for current_finish_index in range(len(self.current_finishes)):
+				current_finish = self.current_finishes[current_finish_index]
+				if len(self.points_repartition) > current_finish_index:
+					current_finish['points_added'] = self.points_repartition[current_finish_index]
+				else:
+					current_finish['points_added'] = self.points_repartition[(len(self.points_repartition) - 1)]
 
-			current_ranking = next((item for item in self.current_rankings if item['login'] == player.login), None)
-			if current_ranking is not None:
-				current_ranking['points_added'] = new_finish['points_added']
-			else:
-				new_finish['score'] = 0
-				self.current_rankings.append(new_finish)
+				current_ranking = next((item for item in self.current_rankings if item['login'] == current_finish['login']), None)
+				if current_ranking is not None:
+					current_ranking['points_added'] = current_finish['points_added']
+				else:
+					current_finish['score'] = 0
+					self.current_rankings.append(current_finish)
 
 			self.current_rankings.sort(key=lambda x: (-x['score'], -x['points_added']))
 			await self.widget.display()


### PR DESCRIPTION
I couldnt find a issue to tie this to but I thought for sure one might already exist. This is my idea of a potential fix for the issue with the points_added on the live rankings widget.

## Motivation or cause

Because the points_added is driven by appending to the `self.current_finishes` whenever a finish event is triggered, player ping can sometimes cause the widget to show the wrong numbers. The player finish event is trigged by each players client sending information to the server. When players have diverse pings to the server it is possible that one finish event can occur on the server first for a player with low ping even if they finished after a player with high ping.

## Change description

In this change, I am re-sorting the `self.current_finishes` array on finish_time each time a new finish event comes in. Then I go through a re-evaluate the points added for all players in the `self.current_rankings` and update their points_added. This way even if the ping issue occurs, when the high ping player's finish event arrives at the server it will resort them into the correct location in the `self.current_finishes` list, they will receive the correct number of points_added, and the low ping player's points_added will also be corrected.

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.

Please leave a comment here if your pull need any updates for the docs or tests.

### Additional Comments (optional)

I was able to test this on my own local server to verify it works for me, but I dont have an environment to test this with many players. I think it would be prudent to test this out with more than one player before merging it in just to be sure I didnt screw it up.
