### PR TITLE
Fix view sort crash on None values

### DIFF
--- a/pyplanet/views/generics/list.py
+++ b/pyplanet/views/generics/list.py
@@ -467,7 +467,7 @@ class ManualListView(ListView):
 
 	async def apply_ordering(self, frame):
 		if self.sort_field:
-			frame.sort(key=lambda e: e[self.sort_field['index']], reverse=not bool(self.sort_order))
+			frame.sort(key=lambda e: e[self.sort_field['index']] or float('inf'), reverse=not bool(self.sort_order))
 		return frame
 
 	async def apply_pagination(self, frame):


### PR DESCRIPTION
## Motivation or cause

If sorting None values, the view crash with the following error :
`TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'`
This is the case when sorting by Rank, Local, or Diff in the Map view, tab Advanced, as they can be empty on some maps.

## Change description

Fix this by using float('inf') to the sort lambda if the index value is None. Effectively pushing the entry at the back of the sort.

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.

Please leave a comment here if your pull need any updates for the docs or tests.

### Additional Comments (optional)

Tested on my server successfully.