### PR TITLE
Fixed sorting None values in list generics.

### DIFF
--- a/pyplanet/views/generics/list.py
+++ b/pyplanet/views/generics/list.py
@@ -467,7 +467,7 @@ class ManualListView(ListView):
 
 	async def apply_ordering(self, frame):
 		if self.sort_field:
-			frame.sort(key=lambda e: e[self.sort_field['index']], reverse=not bool(self.sort_order))
+			frame = sorted(frame, key=lambda e: (e[self.sort_field['index']] is None, e[self.sort_field['index']]), reverse=not bool(self.sort_order))
 		return frame
 
 	async def apply_pagination(self, frame):


### PR DESCRIPTION
Allow sorting on all sorts of data types without crashing on values.
Tested on the `//settings` list with a `None` app setting, and in the advanced list.

Resolves #1245. Supersedes #1242. 