### PR TITLE
Added wait for map info in widget script, to avoid previous author to be displayed.

### DIFF
--- a/pyplanet/apps/contrib/info/templates/mapinfo.Script.Txt
+++ b/pyplanet/apps/contrib/info/templates/mapinfo.Script.Txt
@@ -7,6 +7,7 @@ declare CMlQuad Author_Flag <=> (Page.GetFirstChild("author_flag") as CMlQuad);
 
 declare Boolean Show_Login = False;
 
+wait(Map != Null);
 if (Map != Null) {
   Author_Label.SetText(Map.AuthorNickName);
   Author_Flag.ChangeImageUrl(Map.AuthorZoneIconUrl);


### PR DESCRIPTION
Resolves #1191.

Cannot reproduce the bug, but the widget remains working fine with the change.
Solution thanks to @reaby.