### PR TITLE
Live Rankings: added race rankings widget + made warm-up improvements.

### DIFF
--- a/docs/source/apps/contrib/live_rankings.rst
+++ b/docs/source/apps/contrib/live_rankings.rst
@@ -19,6 +19,8 @@ This app enables the live rankings widget for the game modes:
 - TimeAttack (Top times of players).
 - Cup & Team (Points gathered).
 
+It can also be used to replace the default in-game 'Race Rankings' widget in Rounds, Cup and Team modes.
+While the default widget only displays the first seven finishers, this widget works like the others: displaying more finishers and mainly those around the player.
 
 Installation
 ------------
@@ -34,6 +36,38 @@ Just add this line to your ``apps.py`` file:
       '...',
     ]
   }
+
+
+Settings
+--------
+
+Amount of widget entries
+~~~~~~~~~~~~~~~~~~~~~~~~
+Setting:
+  ``rankings_amount``
+Functionality:
+  Sets the amount of entries to be displayed in the Live & Race Rankings widget (minimum: 15).
+Default value:
+  ``15``
+
+Display in-game race rankings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting:
+  ``nadeo_live_ranking``
+Functionality:
+  Shows the in-game provided race rankings widget (overridden by ``race_live_ranking``).
+Default value:
+  ``True``
+
+Display race rankings
+~~~~~~~~~~~~~~~~~~~~~
+Setting:
+  ``race_live_ranking``
+Functionality:
+  Shows the PyPlanet-provided race rankings widget (overrides ``nadeo_live_ranking``).
+Default value:
+  ``True``
+
 
 Commands
 --------

--- a/pyplanet/apps/contrib/best_cps/view.py
+++ b/pyplanet/apps/contrib/best_cps/view.py
@@ -4,7 +4,7 @@ from pyplanet.views.generics.widget import TimesWidgetView
 
 
 class BestCpTimesWidget(TimesWidgetView):
-	widget_x = -124.75
+	widget_x = -124.5
 	widget_y = 90
 	z_index = 130
 	size_x = 250

--- a/pyplanet/apps/contrib/info/templates/serverinfo.xml
+++ b/pyplanet/apps/contrib/info/templates/serverinfo.xml
@@ -6,7 +6,7 @@
   <label pos="3.25 -3" z-index="1" size="6.5 6" text="&#xf007;" textsize="1.8" halign="center" valign="center2"/>
   <label pos="11.5 -3" z-index="1" size="10 6" text="{{ num_players }}/{{ max_players }}" textsize="1.4" textfont="RajdhaniMono" textemboss="1" halign="center" valign="center2"/>
 
-  <quad pos="17.75 0" z-index="0" size="17 6" bgcolor="00000060"/>
+  <quad pos="17.75 0" z-index="0" size="17.25 6" bgcolor="00000060"/>
   <quad pos="17.75 0" z-index="0" size="6.5 6" bgcolor="00000060"/>
   <label pos="21 -3" z-index="1" size="6.5 6" text="&#xf03d;" textsize="1.8" halign="center" valign="center2"/>
   <label pos="29.5 -3" z-index="1" size="10 6" text="{{ num_spectators }}/{{ max_spectators }}" textsize="1.4" textfont="RajdhaniMono" textemboss="1" halign="center" valign="center2"/>

--- a/pyplanet/apps/contrib/live_rankings/__init__.py
+++ b/pyplanet/apps/contrib/live_rankings/__init__.py
@@ -223,7 +223,7 @@ class LiveRankings(AppConfig):
 		self.current_rankings.sort(key=lambda x: (-x['cps'], x['score']))
 		await self.widget.display()
 
-	async def player_finish(self, player, race_time, lap_time, cps, flow, raw, **kwargs):
+	async def player_finish(self, player, race_time, lap_time, cps, flow, is_end_race, raw, **kwargs):
 		current_script = (await self.instance.mode_manager.get_current_script()).lower()
 		if 'laps' in current_script or 'trackmania/tm_laps_online' in current_script:
 			await self.player_waypoint(player, race_time, flow, raw)
@@ -249,6 +249,11 @@ class LiveRankings(AppConfig):
 
 		if 'rounds' in current_script or 'team' in current_script or 'cup' in current_script or \
 			'trackmania/tm_rounds_online' in current_script or 'trackmania/tm_teams_online' in current_script or 'trackmania/tm_cup_online' in current_script:
+			if not is_end_race:
+				# The finish event is also triggered when passing the finish in a multi-lap map, while not finishing the map.
+				# In that case, no results should be processed as the player hasn't actually finished.
+				return
+
 			new_finish = dict(login=player.login, nickname=player.nickname, score=race_time)
 			self.current_finishes.append(new_finish)
 

--- a/pyplanet/apps/contrib/live_rankings/__init__.py
+++ b/pyplanet/apps/contrib/live_rankings/__init__.py
@@ -1,5 +1,5 @@
 from pyplanet.apps.config import AppConfig
-from pyplanet.apps.contrib.live_rankings.views import LiveRankingsWidget
+from pyplanet.apps.contrib.live_rankings.views import LiveRankingsWidget, RaceRankingsWidget
 
 from pyplanet.apps.core.trackmania import callbacks as tm_signals
 from pyplanet.apps.core.maniaplanet import callbacks as mp_signals
@@ -20,6 +20,9 @@ class LiveRankings(AppConfig):
 		self.widget = None
 		self.dedimania_enabled = False
 
+		self.race_widget = None
+		self.display_race_widget = False
+
 		self.setting_rankings_amount = Setting(
 			'rankings_amount', 'Amount of rankings to display', Setting.CAT_BEHAVIOUR, type=int,
 			description='Amount of live rankings to display (minimum: 15).',
@@ -30,11 +33,16 @@ class LiveRankings(AppConfig):
 			description='Show the Nadeo live rankings widgets besides the live rankings widget.', default=True,
 			change_target=self.nadeo_widget_change
 		)
+		self.setting_race_ranking = Setting(
+			'race_live_ranking', 'Show the race rankings widget', Setting.CAT_BEHAVIOUR, type=bool,
+			description='Show the race rankings widgets besides the live rankings widget.', default=True,
+			change_target=self.race_widget_change
+		)
 
 	async def on_start(self):
 		# Init settings.
 		await self.context.setting.register(
-			self.setting_rankings_amount, self.setting_nadeo_live_ranking
+			self.setting_rankings_amount, self.setting_nadeo_live_ranking, self.setting_race_ranking
 		)
 
 		# Register signals
@@ -47,7 +55,7 @@ class LiveRankings(AppConfig):
 		self.context.signals.listen(tm_signals.scores, self.scores)
 		self.context.signals.listen(tm_signals.warmup_start, self.warmup_start)
 		self.context.signals.listen(tm_signals.warmup_end, self.warmup_end)
-
+		self.context.signals.listen(mp_signals.flow.podium_start, self.podium_start)
 
 		# Make sure we move the multilap_info and disable the checkpoint_ranking and round_scores elements.
 		if self.instance.game.game in ['tm', 'sm']:
@@ -60,6 +68,10 @@ class LiveRankings(AppConfig):
 
 		self.widget = LiveRankingsWidget(self)
 		await self.widget.display()
+
+		# Create the race rankings widget, call setting change method to set the UI accordingly.
+		self.race_widget = RaceRankingsWidget(self)
+		await self.race_widget_change(self)
 
 		scores = None
 		try:
@@ -77,6 +89,21 @@ class LiveRankings(AppConfig):
 		if self.instance.game.game in ['tm', 'sm']:
 			self.instance.ui_manager.properties.set_visibility('round_scores', await self.setting_nadeo_live_ranking.get_value())
 			await self.instance.ui_manager.properties.send_properties()
+
+	async def race_widget_change(self, *args, **kwargs):
+		self.display_race_widget = await self.setting_race_ranking.get_value()
+		if not self.display_race_widget:
+			await self.race_widget.hide()
+
+		# Hide the game-provided race rankings widget when displaying this one.
+		# Otherwise, reset visibility to the Nadeo live ranking setting.
+		if self.instance.game.game in ['tm', 'sm']:
+			if self.display_race_widget is True:
+				self.instance.ui_manager.properties.set_visibility('round_scores', False)
+				await self.instance.ui_manager.properties.send_properties()
+			else:
+				self.instance.ui_manager.properties.set_visibility('round_scores', await self.setting_nadeo_live_ranking.get_value())
+				await self.instance.ui_manager.properties.send_properties()
 
 	def is_mode_supported(self, mode):
 		mode = mode.lower()
@@ -135,6 +162,10 @@ class LiveRankings(AppConfig):
 
 	async def round_start(self, count, time):
 		await self.get_points_repartition()
+		await self.race_widget.hide()
+
+	async def podium_start(self, **kwargs):
+		await self.race_widget.hide()
 
 	async def player_connect(self, player, is_spectator, source, signal):
 		await self.widget.display(player=player)
@@ -144,6 +175,7 @@ class LiveRankings(AppConfig):
 		self.current_finishes = []
 		await self.get_points_repartition()
 		await self.widget.display()
+		await self.race_widget.hide()
 
 	async def warmup_end(self):
 		self.current_rankings = []
@@ -212,7 +244,7 @@ class LiveRankings(AppConfig):
 			return
 
 		if 'rounds' in current_script or 'team' in current_script or 'cup' in current_script or \
-		'trackmania/tm_rounds_online' in current_script or 'trackmania/tm_teams_online' in current_script or 'trackmania/tm_cup_online' in current_script:
+			'trackmania/tm_rounds_online' in current_script or 'trackmania/tm_teams_online' in current_script or 'trackmania/tm_cup_online' in current_script:
 
 			new_finish = dict(login=player.login, nickname=player.nickname, score=race_time)
 			self.current_finishes.append(new_finish)
@@ -231,12 +263,15 @@ class LiveRankings(AppConfig):
 
 			self.current_rankings.sort(key=lambda x: (-x['score'], -x['points_added']))
 			await self.widget.display()
+
+			if self.display_race_widget:
+				await self.race_widget.display()
 			return
 
 	async def get_points_repartition(self):
 		current_script = (await self.instance.mode_manager.get_current_script()).lower()
 		if 'rounds' in current_script or 'team' in current_script or 'cup' in current_script or \
-		'trackmania/tm_rounds_online' in current_script or 'trackmania/tm_teams_online' in current_script or 'trackmania/tm_cup_online' in current_script:
+			'trackmania/tm_rounds_online' in current_script or 'trackmania/tm_teams_online' in current_script or 'trackmania/tm_cup_online' in current_script:
 			points_repartition = await self.instance.gbx('Trackmania.GetPointsRepartition')
 			self.points_repartition = points_repartition['pointsrepartition']
 		else:

--- a/pyplanet/apps/contrib/live_rankings/__init__.py
+++ b/pyplanet/apps/contrib/live_rankings/__init__.py
@@ -254,18 +254,18 @@ class LiveRankings(AppConfig):
 				# In that case, no results should be processed as the player hasn't actually finished.
 				return
 
-			new_finish = dict(login=player.login, nickname=player.nickname, score=race_time)
+			new_finish = dict(login=player.login, nickname=player.nickname, score=race_time, points_added=0)
 			self.current_finishes.append(new_finish)
 			self.current_finishes.sort(key=lambda x: (x['score']))
 
-			for current_finish_index in range(len(self.current_finishes)):
-				current_finish = self.current_finishes[current_finish_index]
-				if len(self.points_repartition) > current_finish_index:
-					current_finish['points_added'] = self.points_repartition[current_finish_index]
-				else:
-					current_finish['points_added'] = self.points_repartition[(len(self.points_repartition) - 1)]
+			if not self.is_warming_up:
+				for current_finish_index in range(len(self.current_finishes)):
+					current_finish = self.current_finishes[current_finish_index]
+					if len(self.points_repartition) > current_finish_index:
+						current_finish['points_added'] = self.points_repartition[current_finish_index]
+					else:
+						current_finish['points_added'] = self.points_repartition[(len(self.points_repartition) - 1)]
 
-				if not self.is_warming_up:
 					current_ranking = next((item for item in self.current_rankings if item['login'] == player.login), None)
 					if current_ranking is not None:
 						current_ranking['points_added'] = new_finish['points_added']

--- a/pyplanet/apps/contrib/live_rankings/templates/race_widget.xml
+++ b/pyplanet/apps/contrib/live_rankings/templates/race_widget.xml
@@ -1,0 +1,20 @@
+{% extends 'core.views/generics/widget.xml' %}
+
+{% block content %}
+  {% if times != None %}
+    {% for time in times %}
+      <frame pos="0 -{{ (loop.index0 * 3.25) }}">
+        <quad pos="0 0" z-index="0" size="4 3" bgcolor="00000070"/>
+        <label pos="2 -1.5" z-index="1" size="4 3" text="{{ time.index }}" textsize="0.3" textfont="RajdhaniMono"  textemboss="1" halign="center" valign="center2"/>
+        <quad pos="4.25 0" z-index="0" size="20.5 3" bgcolor="00000070"/>
+        <label pos="4.5 -1.5" z-index="1" size="20 3" text="{{ time.nickname }}" textsize="0.2" textfont="RajdhaniMono"  textemboss="1" halign="left" valign="center2"/>
+        <quad pos="25 0" z-index="0" size="10 3" bgcolor="00000070"/>
+        <label pos="30 -1.5" z-index="1" size="10 3" text="{{ time.color }}{{ time.score }}" textsize="0.2" textfont="RajdhaniMono"  textemboss="1" halign="center" valign="center2"/>
+        {% if time.points_added != None and time.points_added != 0 %}
+          <quad pos="35.25 0" z-index="0" size="7 3" bgcolor="00000070"/>
+          <label pos="38.75 -1.5" size="7 3" z-index="1" textsize="0.2" halign="center" valign="center2" text="$0f3+{{ time.points_added }}" textfont="RajdhaniMono"  textemboss="1"/>
+        {% endif %}
+      </frame>
+    {% endfor %}
+  {% endif %}
+{% endblock %}

--- a/pyplanet/apps/contrib/live_rankings/views.py
+++ b/pyplanet/apps/contrib/live_rankings/views.py
@@ -209,37 +209,28 @@ class RaceRankingsWidget(TimesWidgetView):
 			records += self.app.current_finishes[self.top_entries:self.record_amount]
 			custom_start_index = (self.top_entries + 1)
 		else:
-			if player_index > len(self.app.current_finishes):
-				# No personal record, get the last records
-				records_start = (len(self.app.current_finishes) - self.record_amount + self.top_entries)
-				# If start of current slice is in the top entries, add more records below
-				if records_start < self.top_entries:
-					records_start = self.top_entries
-
-				records += list(self.app.current_finishes[records_start:])
-				custom_start_index = (records_start + 1)
+			if player_index > len(self.app.current_finishes) or player_index <= self.top_entries:
+				# No personal record, get the best results
+				# Or, player record is in top X, get following records (top entries + 1 onwards)
+				records += list(self.app.current_finishes[self.top_entries:self.record_amount])
+				custom_start_index = (self.top_entries + 1)
 			else:
-				if player_index <= self.top_entries:
-					# Player record is in top X, get following records (top entries + 1 onwards)
-					records += self.app.current_finishes[self.top_entries:self.record_amount]
-					custom_start_index = (self.top_entries + 1)
-				else:
-					# Player record is not in top X, get records around player record
-					# Same amount above the record as below, except when not possible (favors above)
-					records_to_fill = (self.record_amount - self.top_entries)
-					start_point = ((player_index - math.ceil((records_to_fill - 1) / 2)) - 1)
-					end_point = ((player_index + math.floor((records_to_fill - 1) / 2)) - 1)
+				# Player record is not in top X, get records around player record
+				# Same amount above the record as below, except when not possible (favors above)
+				records_to_fill = (self.record_amount - self.top_entries)
+				start_point = ((player_index - math.ceil((records_to_fill - 1) / 2)) - 1)
+				end_point = ((player_index + math.floor((records_to_fill - 1) / 2)) - 1)
 
-					# If end of current slice is outside the list, add more records above
-					if end_point > len(self.app.current_finishes):
-						end_difference = (end_point - len(self.app.current_finishes))
-						start_point = (start_point - end_difference)
-					# If start of current slice is in the top entries, add more records below
-					if start_point < self.top_entries:
-						start_point = self.top_entries
+				# If end of current slice is outside the list, add more records above
+				if end_point > len(self.app.current_finishes):
+					end_difference = (end_point - len(self.app.current_finishes))
+					start_point = (start_point - end_difference)
+				# If start of current slice is in the top entries, add more records below
+				if start_point < self.top_entries:
+					start_point = self.top_entries
 
-					records += self.app.current_finishes[start_point:(start_point + records_to_fill)]
-					custom_start_index = (start_point + 1)
+				records += self.app.current_finishes[start_point:(start_point + records_to_fill)]
+				custom_start_index = (start_point + 1)
 
 		index = 1
 		for record in records:
@@ -253,11 +244,14 @@ class RaceRankingsWidget(TimesWidgetView):
 				if player.flow.team_id == 1:
 					list_record['bgcolor'] = 'F05F5FFF'
 
-			list_record['color'] = '$fff'
-			if index <= self.top_entries:
-				list_record['color'] = '$ff0'
-			if index == player_index:
-				list_record['color'] = '$0f3'
+			if self.app.is_warming_up:
+				list_record['color'] = '$fa0'
+			else:
+				list_record['color'] = '$fff'
+				if index <= self.top_entries:
+					list_record['color'] = '$ff0'
+				if index == player_index:
+					list_record['color'] = '$0f3'
 
 			list_record['nickname'] = record['nickname']
 			list_record['score'] = times.format_time(int(record['score']))

--- a/pyplanet/apps/contrib/live_rankings/views.py
+++ b/pyplanet/apps/contrib/live_rankings/views.py
@@ -200,7 +200,7 @@ class RaceRankingsWidget(TimesWidgetView):
 			player_finish = list()
 
 		if len(player_finish) > 0:
-			# Set player index if there is a record
+			# Set player index if the player has finished.
 			player_index = (self.app.current_finishes.index(player_finish[0]) + 1)
 
 		finishes = list(self.app.current_finishes[:self.top_entries])
@@ -210,22 +210,22 @@ class RaceRankingsWidget(TimesWidgetView):
 			custom_start_index = (self.top_entries + 1)
 		else:
 			if player_index > len(self.app.current_finishes) or player_index <= self.top_entries:
-				# No personal record, get the best results
-				# Or, player record is in top X, get following records (top entries + 1 onwards)
+				# Player not finished, get the best results.
+				# Or, player finished in the top X, get following finishes (top entries + 1 onwards).
 				finishes += list(self.app.current_finishes[self.top_entries:self.record_amount])
 				custom_start_index = (self.top_entries + 1)
 			else:
-				# Player record is not in top X, get records around player record
-				# Same amount above the record as below, except when not possible (favors above)
+				# Player finished not in top X, get finishes around player.
+				# Same amount above the player as below, except when not possible (favors above).
 				records_to_fill = (self.record_amount - self.top_entries)
 				start_point = ((player_index - math.ceil((records_to_fill - 1) / 2)) - 1)
 				end_point = ((player_index + math.floor((records_to_fill - 1) / 2)) - 1)
 
-				# If end of current slice is outside the list, add more records above
+				# If end of current slice is outside the list, add more finishes above
 				if end_point > len(self.app.current_finishes):
 					end_difference = (end_point - len(self.app.current_finishes))
 					start_point = (start_point - end_difference)
-				# If start of current slice is in the top entries, add more records below
+				# If start of current slice is in the top entries, add more finishes below
 				if start_point < self.top_entries:
 					start_point = self.top_entries
 

--- a/pyplanet/apps/contrib/live_rankings/views.py
+++ b/pyplanet/apps/contrib/live_rankings/views.py
@@ -169,3 +169,131 @@ class LiveRankingsWidget(TimesWidgetView):
 			for player in self.app.instance.player_manager.online:
 				data[player.login] = dict(times=self.get_widget_records(player))
 			return data
+
+
+class RaceRankingsWidget(TimesWidgetView):
+	widget_x = -124.5
+	widget_y = 83.5
+	z_index = 130
+	size_x = 38
+	size_y = 55.5
+	top_entries = 5
+	title = 'Race Rankings'
+
+	template_name = 'live_rankings/widget.xml'
+
+	def __init__(self, app):
+		super().__init__(self)
+		self.app = app
+		self.manager = app.context.ui
+		self.id = 'pyplanet__widgets_racerankings'
+
+		self.record_amount = 15
+
+	def get_widget_records(self, player=None):
+		list_records = list()
+
+		player_index = len(self.app.current_finishes) + 1
+		if player:
+			player_record = [x for x in self.app.current_finishes if x['login'] == player.login]
+		else:
+			player_record = list()
+
+		if len(player_record) > 0:
+			# Set player index if there is a record
+			player_index = (self.app.current_finishes.index(player_record[0]) + 1)
+
+		records = list(self.app.current_finishes[:self.top_entries])
+		if self.app.instance.performance_mode:
+			# Performance mode is turned on, get the top of the whole widget.
+			records += self.app.current_finishes[self.top_entries:self.record_amount]
+			custom_start_index = (self.top_entries + 1)
+		else:
+			if player_index > len(self.app.current_finishes):
+				# No personal record, get the last records
+				records_start = (len(self.app.current_finishes) - self.record_amount + self.top_entries)
+				# If start of current slice is in the top entries, add more records below
+				if records_start < self.top_entries:
+					records_start = self.top_entries
+
+				records += list(self.app.current_finishes[records_start:])
+				custom_start_index = (records_start + 1)
+			else:
+				if player_index <= self.top_entries:
+					# Player record is in top X, get following records (top entries + 1 onwards)
+					records += self.app.current_finishes[self.top_entries:self.record_amount]
+					custom_start_index = (self.top_entries + 1)
+				else:
+					# Player record is not in top X, get records around player record
+					# Same amount above the record as below, except when not possible (favors above)
+					records_to_fill = (self.record_amount - self.top_entries)
+					start_point = ((player_index - math.ceil((records_to_fill - 1) / 2)) - 1)
+					end_point = ((player_index + math.floor((records_to_fill - 1) / 2)) - 1)
+
+					# If end of current slice is outside the list, add more records above
+					if end_point > len(self.app.current_finishes):
+						end_difference = (end_point - len(self.app.current_finishes))
+						start_point = (start_point - end_difference)
+					# If start of current slice is in the top entries, add more records below
+					if start_point < self.top_entries:
+						start_point = self.top_entries
+
+					records += self.app.current_finishes[start_point:(start_point + records_to_fill)]
+					custom_start_index = (start_point + 1)
+
+		index = 1
+		for record in records:
+			list_record = dict()
+			list_record['index'] = index
+			list_record['bgcolor'] = '00000070'
+
+			if player:
+				if player.flow.team_id == 0:
+					list_record['bgcolor'] = '7881F2FF'
+				if player.flow.team_id == 1:
+					list_record['bgcolor'] = 'F05F5FFF'
+
+			list_record['color'] = '$fff'
+			if index <= self.top_entries:
+				list_record['color'] = '$ff0'
+			if index == player_index:
+				list_record['color'] = '$0f3'
+
+			list_record['nickname'] = record['nickname']
+			list_record['score'] = times.format_time(int(record['score']))
+			list_record['cp_difference'] = None
+
+			# Points added on finishing in Rounds, Team or Cup modes.
+			if 'points_added' in record:
+				list_record['points_added'] = record['points_added']
+			else:
+				list_record['points_added'] = 0
+
+			if index == self.top_entries:
+				index = custom_start_index
+			else:
+				index += 1
+
+			list_records.append(list_record)
+		return list_records
+
+	async def get_context_data(self):
+		self.record_amount = await self.app.setting_rankings_amount.get_value()
+		if self.record_amount < 15:
+			self.record_amount = 15
+
+		data = await super().get_context_data()
+		if self.app.instance.performance_mode:
+			data['times'] = self.get_widget_records()
+		return data
+
+	async def get_player_data(self):
+		data = await super().get_player_data()
+
+		# If in performance mode, ignore this method.
+		if self.app.instance.performance_mode:
+			return dict()
+		else:
+			for player in self.app.instance.player_manager.online:
+				data[player.login] = dict(times=self.get_widget_records(player))
+			return data

--- a/pyplanet/apps/contrib/live_rankings/views.py
+++ b/pyplanet/apps/contrib/live_rankings/views.py
@@ -180,7 +180,7 @@ class RaceRankingsWidget(TimesWidgetView):
 	top_entries = 5
 	title = 'Race Rankings'
 
-	template_name = 'live_rankings/widget.xml'
+	template_name = 'live_rankings/race_widget.xml'
 
 	def __init__(self, app):
 		super().__init__(self)
@@ -191,28 +191,28 @@ class RaceRankingsWidget(TimesWidgetView):
 		self.record_amount = 15
 
 	def get_widget_records(self, player=None):
-		list_records = list()
+		list_finishes = list()
 
 		player_index = len(self.app.current_finishes) + 1
 		if player:
-			player_record = [x for x in self.app.current_finishes if x['login'] == player.login]
+			player_finish = [x for x in self.app.current_finishes if x['login'] == player.login]
 		else:
-			player_record = list()
+			player_finish = list()
 
-		if len(player_record) > 0:
+		if len(player_finish) > 0:
 			# Set player index if there is a record
-			player_index = (self.app.current_finishes.index(player_record[0]) + 1)
+			player_index = (self.app.current_finishes.index(player_finish[0]) + 1)
 
-		records = list(self.app.current_finishes[:self.top_entries])
+		finishes = list(self.app.current_finishes[:self.top_entries])
 		if self.app.instance.performance_mode:
 			# Performance mode is turned on, get the top of the whole widget.
-			records += self.app.current_finishes[self.top_entries:self.record_amount]
+			finishes += self.app.current_finishes[self.top_entries:self.record_amount]
 			custom_start_index = (self.top_entries + 1)
 		else:
 			if player_index > len(self.app.current_finishes) or player_index <= self.top_entries:
 				# No personal record, get the best results
 				# Or, player record is in top X, get following records (top entries + 1 onwards)
-				records += list(self.app.current_finishes[self.top_entries:self.record_amount])
+				finishes += list(self.app.current_finishes[self.top_entries:self.record_amount])
 				custom_start_index = (self.top_entries + 1)
 			else:
 				# Player record is not in top X, get records around player record
@@ -229,47 +229,41 @@ class RaceRankingsWidget(TimesWidgetView):
 				if start_point < self.top_entries:
 					start_point = self.top_entries
 
-				records += self.app.current_finishes[start_point:(start_point + records_to_fill)]
+				finishes += self.app.current_finishes[start_point:(start_point + records_to_fill)]
 				custom_start_index = (start_point + 1)
 
 		index = 1
-		for record in records:
-			list_record = dict()
-			list_record['index'] = index
-			list_record['bgcolor'] = '00000070'
+		for finish in finishes:
+			list_finish = dict()
+			list_finish['index'] = index
+			list_finish['bgcolor'] = '00000070'
 
 			if player:
 				if player.flow.team_id == 0:
-					list_record['bgcolor'] = '7881F2FF'
+					list_finish['bgcolor'] = '7881F2FF'
 				if player.flow.team_id == 1:
-					list_record['bgcolor'] = 'F05F5FFF'
+					list_finish['bgcolor'] = 'F05F5FFF'
 
 			if self.app.is_warming_up:
-				list_record['color'] = '$fa0'
+				list_finish['color'] = '$fa0'
 			else:
-				list_record['color'] = '$fff'
+				list_finish['color'] = '$fff'
 				if index <= self.top_entries:
-					list_record['color'] = '$ff0'
+					list_finish['color'] = '$ff0'
 				if index == player_index:
-					list_record['color'] = '$0f3'
+					list_finish['color'] = '$0f3'
 
-			list_record['nickname'] = record['nickname']
-			list_record['score'] = times.format_time(int(record['score']))
-			list_record['cp_difference'] = None
-
-			# Points added on finishing in Rounds, Team or Cup modes.
-			if 'points_added' in record:
-				list_record['points_added'] = record['points_added']
-			else:
-				list_record['points_added'] = 0
+			list_finish['nickname'] = finish['nickname']
+			list_finish['score'] = times.format_time(int(finish['score']))
+			list_finish['points_added'] = finish['points_added']
 
 			if index == self.top_entries:
 				index = custom_start_index
 			else:
 				index += 1
 
-			list_records.append(list_record)
-		return list_records
+			list_finishes.append(list_finish)
+		return list_finishes
 
 	async def get_context_data(self):
 		self.record_amount = await self.app.setting_rankings_amount.get_value()


### PR DESCRIPTION
Resolves #1097.

All changes only related to the Rounds/Team/Cup modes, no changes were made to the other modes.
Will no longer display (useless) Live Rankings standings in warm-up mode.
Added race rankings widget to replace the in-game provided one that only displays the first seven finishers.
(Slightly rearranged the serverinfo (spectator box) + best cps to make sure all boxes line up fine.)

Only tested on ManiaPlanet. Requires more testing (also on TM2020), with more than just one player.

Normal round:
![image](https://github.com/PyPlanet/PyPlanet/assets/1104988/7f97506c-ac1e-4667-812e-a86945146512)

Warm-up round:
![image](https://github.com/PyPlanet/PyPlanet/assets/1104988/19e07124-1830-4cbe-8c7f-13767c09b014)
