### PR TITLE
Add round pause and unpause commands

### DIFF
--- a/docs/source/apps/contrib/admin.rst
+++ b/docs/source/apps/contrib/admin.rst
@@ -348,6 +348,28 @@ Functionality:
 Required permission:
   ``admin:points_repartition``, requires admin level 2.
 
+Pause running round
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Command:
+  ``//pause``
+Parameters:
+  None
+Functionality:
+  Skips the running round and pauses the match until an admin resumes the match
+Required permission:
+  ``admin:pause``, requires admin level 2.
+
+End running pause
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Command:
+  ``//unpause`` / ``//endpause`` / ``//resume``
+Parameters:
+  None
+Functionality:
+  Ends the running pause and resumes the match
+Required permission:
+  ``admin:pause``, requires admin level 2.
+
 Write Blacklist
 ~~~~~~~~~~~~~~~
 Command:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please replace {Please write here} with your description -->

## Motivation or cause

Had player game crash during match, pause command would have avoided them being eliminated due to technical issue

## Change description

Added pause and unpause command to the admin flow contrib plugin, and added a new permission for admin:pause

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.
