### PR TITLE
Add more aliases for game modes

### DIFF
--- a/docs/source/apps/contrib/admin.rst
+++ b/docs/source/apps/contrib/admin.rst
@@ -434,7 +434,7 @@ Set game mode
 Command:
   ``//mode``
 Parameters:
-  * Game mode 'ta', 'laps', 'rounds', 'cup' or any script name (e.g. 'Rounds.Script.txt')
+  * Game mode 'ta', 'timeattack', 'laps', 'rounds', 'cup', 'team', 'teams', 'ko', 'knockout', 'champion', 'royal', 'stunt', 'platform' or any script name (e.g. 'Rounds.Script.txt')
 Functionality:
   Changes the server game mode script.
 Required permission:

--- a/pyplanet/apps/contrib/admin/server.py
+++ b/pyplanet/apps/contrib/admin/server.py
@@ -115,9 +115,9 @@ class ServerAdmin:
 				mode = 'Trackmania/TM_Rounds_Online.Script.txt'
 			elif lower_mode == 'cup':
 				mode = 'Trackmania/TM_Cup_Online.Script.txt'
-			elif lower_mode == 'team':
+			elif lower_mode == 'team' or lower_mode == 'teams':
 				mode = 'Trackmania/TM_Teams_Online.Script.txt'
-			elif lower_mode == 'knockout':
+			elif lower_mode == 'ko' or lower_mode == 'knockout':
 				mode = 'Trackmania/TM_Knockout_Online.Script.txt'
 			elif lower_mode == 'champion':
 				mode = 'Trackmania/TM_Champion_Online.Script.txt'

--- a/pyplanet/apps/contrib/admin/server.py
+++ b/pyplanet/apps/contrib/admin/server.py
@@ -121,6 +121,12 @@ class ServerAdmin:
 				mode = 'Trackmania/TM_Knockout_Online.Script.txt'
 			elif lower_mode == 'champion':
 				mode = 'Trackmania/TM_Champion_Online.Script.txt'
+			elif lower_mode == 'royal':
+				mode = 'Trackmania/TM_RoyalTimeAttack_Online.Script.txt'
+			elif lower_mode == 'stunt':
+				mode = 'Trackmania/TM_StuntMulti_Online.Script.txt'
+			elif lower_mode == 'platform':
+				mode = 'Trackmania/TM_Platform_Online.Script.txt'
 
 		try:
 			await self.instance.mode_manager.set_next_script(mode)

--- a/pyplanet/apps/contrib/admin/server.py
+++ b/pyplanet/apps/contrib/admin/server.py
@@ -120,7 +120,7 @@ class ServerAdmin:
 			elif lower_mode == 'ko' or lower_mode == 'knockout':
 				mode = 'Trackmania/TM_Knockout_Online.Script.txt'
 			elif lower_mode == 'champion':
-				mode = 'Trackmania/TM_Champion_Online.Script.txt'
+				mode = 'Trackmania/Deprecated/TM_Champion_Online.Script.txt'
 			elif lower_mode == 'royal':
 				mode = 'Trackmania/TM_RoyalTimeAttack_Online.Script.txt'
 			elif lower_mode == 'stunt':


### PR DESCRIPTION
<!-- Thank you for your contribution! Please replace {Please write here} with your description -->

## Motivation or cause

To close #1338. Having aliases for the new modes would be nice.

## Change description

Edits the admin plugin to add aliases for Royal Time Attack, Stunt, and Platform modes in TM2020, as well and add the "teams" and "ko" aliases for Teams and Knockout

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.

Please leave a comment here if your pull need any updates for the docs or tests.