### PR TITLE
Fix typo in configuration documentation example

### DIFF
--- a/docs/source/intro/configuration.rst
+++ b/docs/source/intro/configuration.rst
@@ -586,7 +586,7 @@ The order doesn't make a difference when starting/loading PyPlanet.
       - 'pyplanet.apps.contrib.music_server'
 
       # New since 0.8.0:
-      - 'pyplanet.apps.contrib.funcmd
+      - 'pyplanet.apps.contrib.funcmd'
 
       # New since 0.10.0:
       - 'pyplanet.apps.contrib.rankings'


### PR DESCRIPTION
Corrected a missing closing quote in the example code for better clarity and accuracy. This ensures proper syntax and avoids confusion for users referencing the documentation.
