### PR TITLE
fix: make ID3 tag search case insensitive

### DIFF
--- a/pyplanet/apps/contrib/music_server/__init__.py
+++ b/pyplanet/apps/contrib/music_server/__init__.py
@@ -155,9 +155,9 @@ class MusicServer(AppConfig):
 					'genre': 'genre'
 				}
 				for key, value in tags.items():
-					if fs.find(key.upper()) > 0:
-						end_of_key = fs.find(key.upper()) + len(key) + 1
-						end_of_value = fs.find('\\x', fs.find(key.upper()))
+					if fs.find(key.casefold()) > 0:
+						end_of_key = fs.find(key.casefold()) + len(key) + 1
+						end_of_value = fs.find('\\x', fs.find(key.casefold()))
 						value = fs[end_of_key:end_of_value]
 						if value.find('(') > 0 or value.find('[') > 0:
 							tags[key] = re.sub(r'[^a-zA-Z\d\s\)\]]$', '', value).replace('\\', '')


### PR DESCRIPTION
## Motivation or cause

songs in songlist on server didn't load ID3 tags #1358

## Change description

fixes the music_server app being unable to retrieve ID3 tags if they're not uppercase in the .ogg file

## Checklist of pull request

- [X]  I have read the **CONTRIBUTING** document.
- [X]  My code follows the code style of this project.
- [X]  All new and existing tests passed, except in few situations.
- [ ]  My change requires a change to the documentation.
