### PR TITLE
Replace Ogg tag extraction code with tinytag library (re:issue 1361)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,6 @@ raven==6.10.0
 xmltodict==0.12.0
 PyYAML==6.0.2
 packaging<=23.1
+tinytag==2.1.2
 
 cryptography==40.0.2


### PR DESCRIPTION
<!-- Thank you for your contribution! Please replace {Please write here} with your description -->

## Motivation or cause

Resolve fragile Ogg tag extraction code in music_server which relies on `string.find()` and regex for cleanup rather than parsing the file format properly, per issue #1361 

## Change description

Added a new dependency on the Python [tinytag](https://pypi.org/project/tinytag/) project for more robust tag extraction and implemented its use in music_server

## Checklist of pull request

Make sure that your pull request follow the following 'rules':

- I have read the **CONTRIBUTING** document.
- My code follows the code style of this project.
- All new and existing tests passed, except in few situations.
- My change requires a change to the documentation.

Please leave a comment here if your pull need any updates for the docs or tests.

### Additional Comments (optional)

Tested to also handle #1359 (tinytag seems to handle lower or mixed-case tag keys just fine)
